### PR TITLE
Wire the source editor and the Toolbar + Refactoring

### DIFF
--- a/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecManager.java
+++ b/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecManager.java
@@ -156,23 +156,23 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecView> {
 
     @Override
     protected void addEventEmitters(final ThemedReactContext reactContext, final ReactAztecView aztecView) {
-        final ReactAztecText editText = aztecView.getAztecText();
-        editText.addTextChangedListener(new AztecTextWatcher(reactContext, aztecView));
-        editText.setOnFocusChangeListener(
+        aztecView.getAztecText().addTextChangedListener(new AztecTextWatcher(reactContext, aztecView));
+        aztecView.getAztecText().setOnFocusChangeListener(
                 new View.OnFocusChangeListener() {
                     public void onFocusChange(View v, boolean hasFocus) {
                         EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+                        final ReactAztecText editText = (ReactAztecText)v;
                         if (hasFocus) {
                             eventDispatcher.dispatchEvent(
                                     new ReactAztecFocusEvent(
-                                            aztecView.getId())); // TODO is the correct ID?
+                                            aztecView.getId()));
                         } else {
                             eventDispatcher.dispatchEvent(
                                     new ReactAztecBlurEvent(
                                             aztecView.getId()));
 
                             eventDispatcher.dispatchEvent(
-                                    new ReactaztecEndEditingEvent(
+                                    new ReactAztecEndEditingEvent(
                                             aztecView.getId(),
                                             editText.getText().toString()));
                         }

--- a/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecManager.java
+++ b/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecManager.java
@@ -155,26 +155,25 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecView> {
     }
 
     @Override
-    protected void addEventEmitters(final ThemedReactContext reactContext, final ReactAztecView container) {
-        final ReactAztecText editText = container.getAztecText();
-        editText.addTextChangedListener(new AztecTextWatcher(reactContext, editText));
+    protected void addEventEmitters(final ThemedReactContext reactContext, final ReactAztecView aztecView) {
+        final ReactAztecText editText = aztecView.getAztecText();
+        editText.addTextChangedListener(new AztecTextWatcher(reactContext, aztecView));
         editText.setOnFocusChangeListener(
                 new View.OnFocusChangeListener() {
                     public void onFocusChange(View v, boolean hasFocus) {
-                        EventDispatcher eventDispatcher =
-                                reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+                        EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
                         if (hasFocus) {
                             eventDispatcher.dispatchEvent(
                                     new ReactAztecFocusEvent(
-                                            editText.getId())); // TODO is the correct ID?
+                                            aztecView.getId())); // TODO is the correct ID?
                         } else {
                             eventDispatcher.dispatchEvent(
                                     new ReactAztecBlurEvent(
-                                            editText.getId()));
+                                            aztecView.getId()));
 
                             eventDispatcher.dispatchEvent(
                                     new ReactaztecEndEditingEvent(
-                                            editText.getId(),
+                                            aztecView.getId(),
                                             editText.getText().toString()));
                         }
                     }
@@ -188,13 +187,13 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecView> {
 
         private EventDispatcher mEventDispatcher;
         private ReactAztecText mEditText;
+        private ReactAztecView mAztecView;
         private String mPreviousText;
 
-        public AztecTextWatcher(
-                final ReactContext reactContext,
-                final ReactAztecText editText) {
+        public AztecTextWatcher(final ReactContext reactContext, final ReactAztecView aztec) {
             mEventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
-            mEditText = editText;
+            mAztecView = aztec;
+            mEditText = aztec.getAztecText();
             mPreviousText = null;
         }
 
@@ -224,13 +223,13 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecView> {
             // TODO: t7936714 merge these events
             mEventDispatcher.dispatchEvent(
                     new ReactTextChangedEvent(
-                            mEditText.getId(),
+                            mAztecView.getId(),
                             s.toString(),
                             mEditText.incrementAndGetEventCounter()));
 
             mEventDispatcher.dispatchEvent(
                     new ReactTextInputEvent(
-                            mEditText.getId(),
+                            mAztecView.getId(),
                             newText,
                             oldText,
                             start,

--- a/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecManager.java
+++ b/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecManager.java
@@ -26,6 +26,12 @@ import com.facebook.react.views.textinput.ReactTextChangedEvent;
 import com.facebook.react.views.textinput.ReactTextInputEvent;
 import com.facebook.react.views.textinput.ScrollWatcher;
 
+import org.jetbrains.annotations.NotNull;
+import org.wordpress.aztec.ITextFormat;
+import org.wordpress.aztec.source.SourceViewEditText;
+import org.wordpress.aztec.toolbar.AztecToolbar;
+import org.wordpress.aztec.toolbar.IAztecToolbarClickListener;
+
 import java.util.Map;
 
 public class ReactAztecManager extends SimpleViewManager<ReactAztecView> {
@@ -49,7 +55,20 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecView> {
         ReactAztecView aztecView = (ReactAztecView) li.inflate(R.layout.aztec_main, null);
         ReactAztecText aztecText = aztecView.findViewById(R.id.aztec);
         aztecView.setAztecText(aztecText);
-        // TODO: init toolbar here
+        SourceViewEditText sourceEditor = aztecView.findViewById(R.id.source);
+        aztecView.setSourceEditor(sourceEditor);
+        AztecToolbar toolbar = aztecView.findViewById(R.id.formatting_toolbar);
+        aztecView.setToolbar(toolbar);
+
+        // init Toolbar
+        toolbar.setEditor(aztecText, sourceEditor);
+        toolbar.setToolbarListener(new ToolbarClickListener(aztecView));
+        aztecText.setToolbar(toolbar);
+        //initSourceEditorHistory();
+
+        aztecText.setCalypsoMode(false);
+        sourceEditor.setCalypsoMode(false);
+
         return aztecView;
     }
 
@@ -94,6 +113,7 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecView> {
     @ReactProp(name = "text")
     public void setText(ReactAztecView view, String text) {
         view.getAztecText().fromHtml(text);
+        view.getSourceEditor().displayStyledAndFormattedHtml(text);
     }
 
     @ReactProp(name = "color")
@@ -222,6 +242,49 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecView> {
         }
     }
 
+    private class ToolbarClickListener implements IAztecToolbarClickListener {
+        private ReactAztecView mAztecView;
+
+        public ToolbarClickListener(ReactAztecView aztecView) {
+            this.mAztecView = aztecView;
+        }
+
+        @Override
+        public void onToolbarCollapseButtonClicked() {
+
+        }
+
+        @Override
+        public void onToolbarExpandButtonClicked() {
+
+        }
+
+        @Override
+        public void onToolbarFormatButtonClicked(@NotNull ITextFormat format, boolean isKeyboardShortcut) {
+
+        }
+
+        @Override
+        public void onToolbarHeadingButtonClicked() {
+
+        }
+
+        @Override
+        public void onToolbarHtmlButtonClicked() {
+            mAztecView.getToolbar().toggleEditorMode();
+        }
+
+        @Override
+        public void onToolbarListButtonClicked() {
+
+        }
+
+        @Override
+        public boolean onToolbarMediaButtonClicked() {
+            return false;
+        }
+    }
+
     private class AztecContentSizeWatcher implements com.facebook.react.views.textinput.ContentSizeWatcher {
         private ReactAztecView mReactAztecView;
         private EventDispatcher mEventDispatcher;
@@ -252,10 +315,10 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecView> {
                 mPreviousContentHeight = contentHeight;
                 mPreviousContentWidth = contentWidth;
 
-                // FIXME: Note the hack here
+                // FIXME: Note the 2 hacks here
                 mEventDispatcher.dispatchEvent(
                         new ReactContentSizeChangedEvent(
-                                mReactAztecView.getId(), // Note the ID of teh parent here ;)
+                                mReactAztecView.getId(), // Note the ID of the parent here ;)
                                 PixelUtil.toDIPFromPixel(contentWidth) + 48,
                                 PixelUtil.toDIPFromPixel(contentHeight) + 48));
             }

--- a/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecText.java
+++ b/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecText.java
@@ -37,12 +37,10 @@ public class ReactAztecText extends AztecText {
     private @Nullable ContentSizeWatcher mContentSizeWatcher;
     private @Nullable ScrollWatcher mScrollWatcher;
 
+    // FIXME: Used in `incrementAndGetEventCounter` but never read. I guess we can get rid of it, but before this
+    // check when it's used in EditText in RN. (maybe tests?)
     private int mNativeEventCount = 0;
 
-   /* public ReactAztecText(ThemedReactContext reactContext, Context context) {
-       this(context, null);
-    }
-*/
     public ReactAztecText(Context context, AttributeSet attrs) {
         super(context, attrs);
         initEditor(context);
@@ -56,7 +54,7 @@ public class ReactAztecText extends AztecText {
         addPlugin(new AudioShortcodePlugin());
         addPlugin(new CssUnderlinePlugin());
         this.setImageGetter(new GlideImageLoader(context));
-        //this.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(context));
+        this.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(context));
     }
 
     @Override

--- a/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecText.java
+++ b/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecText.java
@@ -7,14 +7,15 @@ import android.text.TextWatcher;
 import android.util.AttributeSet;
 
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.views.textinput.ContentSizeWatcher;
 import com.facebook.react.views.textinput.ReactTextInputLocalData;
 import com.facebook.react.views.textinput.ScrollWatcher;
 
 import org.wordpress.aztec.AztecText;
+import org.wordpress.aztec.plugins.CssUnderlinePlugin;
 import org.wordpress.aztec.plugins.IAztecPlugin;
+import org.wordpress.aztec.plugins.IToolbarButton;
 import org.wordpress.aztec.plugins.shortcodes.AudioShortcodePlugin;
 import org.wordpress.aztec.plugins.shortcodes.CaptionShortcodePlugin;
 import org.wordpress.aztec.plugins.shortcodes.VideoShortcodePlugin;
@@ -38,31 +39,24 @@ public class ReactAztecText extends AztecText {
 
     private int mNativeEventCount = 0;
 
-    public ReactAztecText(ThemedReactContext reactContext, Context context) {
-        super(context);
-       /* this.setFocusableInTouchMode(true);
-        this.setFocusable(true);
+   /* public ReactAztecText(ThemedReactContext reactContext, Context context) {
+       this(context, null);
+    }
+*/
+    public ReactAztecText(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        initEditor(context);
+    }
 
+    private void initEditor(Context context) {
         addPlugin(new WordPressCommentsPlugin(this));
         addPlugin(new MoreToolbarButton(this));
         addPlugin(new CaptionShortcodePlugin(this));
         addPlugin(new VideoShortcodePlugin());
         addPlugin(new AudioShortcodePlugin());
+        addPlugin(new CssUnderlinePlugin());
         this.setImageGetter(new GlideImageLoader(context));
-        this.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(context));*/
-    }
-
-    public ReactAztecText(Context context, AttributeSet attrs) {
-        super(context, attrs, 0);
-        this.setFocusableInTouchMode(true);
-        this.setFocusable(true);
-      /*  addPlugin(new WordPressCommentsPlugin(this));
-        addPlugin(new MoreToolbarButton(this));
-        addPlugin(new CaptionShortcodePlugin(this));
-        addPlugin(new VideoShortcodePlugin());
-        addPlugin(new AudioShortcodePlugin());
-        this.setImageGetter(new GlideImageLoader(context));
-        this.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(context));*/
+        //this.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(context));
     }
 
     @Override
@@ -73,10 +67,9 @@ public class ReactAztecText extends AztecText {
 
     private void addPlugin(IAztecPlugin plugin) {
         super.getPlugins().add(plugin);
-       /* if (plugin instanceof IToolbarButton) {
-            toolbar.addButton(plugin)
+        if (plugin instanceof IToolbarButton && getToolbar() != null ) {
+            getToolbar().addButton((IToolbarButton)plugin);
         }
-*/
     }
 
     public void setScrollWatcher(ScrollWatcher scrollWatcher) {

--- a/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecText.java
+++ b/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecText.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.support.annotation.Nullable;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.util.AttributeSet;
 
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -39,7 +40,7 @@ public class ReactAztecText extends AztecText {
 
     public ReactAztecText(ThemedReactContext reactContext, Context context) {
         super(context);
-        this.setFocusableInTouchMode(true);
+       /* this.setFocusableInTouchMode(true);
         this.setFocusable(true);
 
         addPlugin(new WordPressCommentsPlugin(this));
@@ -48,7 +49,20 @@ public class ReactAztecText extends AztecText {
         addPlugin(new VideoShortcodePlugin());
         addPlugin(new AudioShortcodePlugin());
         this.setImageGetter(new GlideImageLoader(context));
-        this.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(context));
+        this.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(context));*/
+    }
+
+    public ReactAztecText(Context context, AttributeSet attrs) {
+        super(context, attrs, 0);
+        this.setFocusableInTouchMode(true);
+        this.setFocusable(true);
+      /*  addPlugin(new WordPressCommentsPlugin(this));
+        addPlugin(new MoreToolbarButton(this));
+        addPlugin(new CaptionShortcodePlugin(this));
+        addPlugin(new VideoShortcodePlugin());
+        addPlugin(new AudioShortcodePlugin());
+        this.setImageGetter(new GlideImageLoader(context));
+        this.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(context));*/
     }
 
     @Override

--- a/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecText.java
+++ b/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecText.java
@@ -1,0 +1,174 @@
+package com.example.android.ReactAztec;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.text.Editable;
+import android.text.TextWatcher;
+
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.views.textinput.ContentSizeWatcher;
+import com.facebook.react.views.textinput.ReactTextInputLocalData;
+import com.facebook.react.views.textinput.ScrollWatcher;
+
+import org.wordpress.aztec.AztecText;
+import org.wordpress.aztec.plugins.IAztecPlugin;
+import org.wordpress.aztec.plugins.shortcodes.AudioShortcodePlugin;
+import org.wordpress.aztec.plugins.shortcodes.CaptionShortcodePlugin;
+import org.wordpress.aztec.plugins.shortcodes.VideoShortcodePlugin;
+import org.wordpress.aztec.plugins.wpcomments.WordPressCommentsPlugin;
+import org.wordpress.aztec.plugins.wpcomments.toolbar.MoreToolbarButton;
+import org.wordpress.aztec.glideloader.GlideImageLoader;
+import org.wordpress.aztec.glideloader.GlideVideoThumbnailLoader;
+
+import java.util.ArrayList;
+
+public class ReactAztecText extends AztecText {
+
+    // This flag is set to true when we set the text of the EditText explicitly. In that case, no
+    // *TextChanged events should be triggered. This is less expensive than removing the text
+    // listeners and adding them back again after the text change is completed.
+    private boolean mIsSettingTextFromJS = false;
+    private @Nullable ArrayList<TextWatcher> mListeners;
+    private @Nullable TextWatcherDelegator mTextWatcherDelegator;
+    private @Nullable ContentSizeWatcher mContentSizeWatcher;
+    private @Nullable ScrollWatcher mScrollWatcher;
+
+    private int mNativeEventCount = 0;
+
+    public ReactAztecText(ThemedReactContext reactContext, Context context) {
+        super(context);
+        this.setFocusableInTouchMode(true);
+        this.setFocusable(true);
+
+        addPlugin(new WordPressCommentsPlugin(this));
+        addPlugin(new MoreToolbarButton(this));
+        addPlugin(new CaptionShortcodePlugin(this));
+        addPlugin(new VideoShortcodePlugin());
+        addPlugin(new AudioShortcodePlugin());
+        this.setImageGetter(new GlideImageLoader(context));
+        this.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(context));
+    }
+
+    @Override
+    public void refreshText() {
+        super.refreshText();
+        onContentSizeChange();
+    }
+
+    private void addPlugin(IAztecPlugin plugin) {
+        super.getPlugins().add(plugin);
+       /* if (plugin instanceof IToolbarButton) {
+            toolbar.addButton(plugin)
+        }
+*/
+    }
+
+    public void setScrollWatcher(ScrollWatcher scrollWatcher) {
+        mScrollWatcher = scrollWatcher;
+    }
+
+    @Override
+    protected void onScrollChanged(int horiz, int vert, int oldHoriz, int oldVert) {
+        super.onScrollChanged(horiz, vert, oldHoriz, oldVert);
+
+        if (mScrollWatcher != null) {
+            mScrollWatcher.onScrollChanged(horiz, vert, oldHoriz, oldVert);
+        }
+    }
+
+    public void setContentSizeWatcher(ContentSizeWatcher contentSizeWatcher) {
+        mContentSizeWatcher = contentSizeWatcher;
+    }
+
+    private void onContentSizeChange() {
+        if (mContentSizeWatcher != null) {
+            mContentSizeWatcher.onLayout();
+        }
+
+        setIntrinsicContentSize();
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        onContentSizeChange();
+    }
+
+    private void setIntrinsicContentSize() {
+        ReactContext reactContext = (ReactContext) getContext();
+        UIManagerModule uiManager = reactContext.getNativeModule(UIManagerModule.class);
+        final ReactTextInputLocalData localData = new ReactTextInputLocalData(this);
+        uiManager.setViewLocalData(getId(), localData);
+    }
+
+    //// Text changed events
+
+    public int incrementAndGetEventCounter() {
+        return ++mNativeEventCount;
+    }
+
+    @Override
+    public void addTextChangedListener(TextWatcher watcher) {
+        if (mListeners == null) {
+            mListeners = new ArrayList<>();
+            super.addTextChangedListener(getTextWatcherDelegator());
+        }
+
+        mListeners.add(watcher);
+    }
+
+    @Override
+    public void removeTextChangedListener(TextWatcher watcher) {
+        if (mListeners != null) {
+            mListeners.remove(watcher);
+
+            if (mListeners.isEmpty()) {
+                mListeners = null;
+                super.removeTextChangedListener(getTextWatcherDelegator());
+            }
+        }
+    }
+
+    private TextWatcherDelegator getTextWatcherDelegator() {
+        if (mTextWatcherDelegator == null) {
+            mTextWatcherDelegator = new TextWatcherDelegator();
+        }
+        return mTextWatcherDelegator;
+    }
+
+    /**
+     * This class will redirect *TextChanged calls to the listeners only in the case where the text
+     * is changed by the user, and not explicitly set by JS.
+     */
+    private class TextWatcherDelegator implements TextWatcher {
+        @Override
+        public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            if (!mIsSettingTextFromJS && mListeners != null) {
+                for (TextWatcher listener : mListeners) {
+                    listener.beforeTextChanged(s, start, count, after);
+                }
+            }
+        }
+
+        @Override
+        public void onTextChanged(CharSequence s, int start, int before, int count) {
+            if (!mIsSettingTextFromJS && mListeners != null) {
+                for (TextWatcher listener : mListeners) {
+                    listener.onTextChanged(s, start, before, count);
+                }
+            }
+
+            onContentSizeChange();
+        }
+
+        @Override
+        public void afterTextChanged(Editable s) {
+            if (!mIsSettingTextFromJS && mListeners != null) {
+                for (TextWatcher listener : mListeners) {
+                    listener.afterTextChanged(s);
+                }
+            }
+        }
+    }
+}

--- a/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecView.java
+++ b/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecView.java
@@ -1,21 +1,25 @@
 package com.example.android.ReactAztec;
 
 import android.content.Context;
+import android.util.AttributeSet;
 import android.widget.RelativeLayout;
 
 public class ReactAztecView extends RelativeLayout {
     private ReactAztecText aztecText;
 
-    ReactAztecView(Context ctx) {
+    public ReactAztecView(Context ctx) {
         super(ctx);
     }
 
-    public ReactAztecText getAztecText() {
+    public ReactAztecView(Context ctx, AttributeSet attrs) {
+        super(ctx, attrs);
+    }
+
+    ReactAztecText getAztecText() {
         return aztecText;
     }
 
-    public void setAztecText(ReactAztecText aztecText) {
+    void setAztecText(ReactAztecText aztecText) {
         this.aztecText = aztecText;
-        this.addView(aztecText);
     }
 }

--- a/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecView.java
+++ b/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecView.java
@@ -1,174 +1,21 @@
 package com.example.android.ReactAztec;
 
 import android.content.Context;
-import android.support.annotation.Nullable;
-import android.text.Editable;
-import android.text.TextWatcher;
+import android.widget.RelativeLayout;
 
-import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.UIManagerModule;
-import com.facebook.react.views.textinput.ContentSizeWatcher;
-import com.facebook.react.views.textinput.ReactTextInputLocalData;
-import com.facebook.react.views.textinput.ScrollWatcher;
+public class ReactAztecView extends RelativeLayout {
+    private ReactAztecText aztecText;
 
-import org.wordpress.aztec.AztecText;
-import org.wordpress.aztec.plugins.IAztecPlugin;
-import org.wordpress.aztec.plugins.shortcodes.AudioShortcodePlugin;
-import org.wordpress.aztec.plugins.shortcodes.CaptionShortcodePlugin;
-import org.wordpress.aztec.plugins.shortcodes.VideoShortcodePlugin;
-import org.wordpress.aztec.plugins.wpcomments.WordPressCommentsPlugin;
-import org.wordpress.aztec.plugins.wpcomments.toolbar.MoreToolbarButton;
-import org.wordpress.aztec.glideloader.GlideImageLoader;
-import org.wordpress.aztec.glideloader.GlideVideoThumbnailLoader;
-
-import java.util.ArrayList;
-
-public class ReactAztecView extends AztecText {
-
-    // This flag is set to true when we set the text of the EditText explicitly. In that case, no
-    // *TextChanged events should be triggered. This is less expensive than removing the text
-    // listeners and adding them back again after the text change is completed.
-    private boolean mIsSettingTextFromJS = false;
-    private @Nullable ArrayList<TextWatcher> mListeners;
-    private @Nullable TextWatcherDelegator mTextWatcherDelegator;
-    private @Nullable ContentSizeWatcher mContentSizeWatcher;
-    private @Nullable ScrollWatcher mScrollWatcher;
-
-    private int mNativeEventCount = 0;
-
-    public ReactAztecView(ThemedReactContext reactContext, Context context) {
-        super(context);
-        this.setFocusableInTouchMode(true);
-        this.setFocusable(true);
-
-        addPlugin(new WordPressCommentsPlugin(this));
-        addPlugin(new MoreToolbarButton(this));
-        addPlugin(new CaptionShortcodePlugin(this));
-        addPlugin(new VideoShortcodePlugin());
-        addPlugin(new AudioShortcodePlugin());
-        this.setImageGetter(new GlideImageLoader(context));
-        this.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(context));
+    ReactAztecView(Context ctx) {
+        super(ctx);
     }
 
-    @Override
-    public void refreshText() {
-        super.refreshText();
-        onContentSizeChange();
+    public ReactAztecText getAztecText() {
+        return aztecText;
     }
 
-    private void addPlugin(IAztecPlugin plugin) {
-        super.getPlugins().add(plugin);
-       /* if (plugin instanceof IToolbarButton) {
-            toolbar.addButton(plugin)
-        }
-*/
-    }
-
-    public void setScrollWatcher(ScrollWatcher scrollWatcher) {
-        mScrollWatcher = scrollWatcher;
-    }
-
-    @Override
-    protected void onScrollChanged(int horiz, int vert, int oldHoriz, int oldVert) {
-        super.onScrollChanged(horiz, vert, oldHoriz, oldVert);
-
-        if (mScrollWatcher != null) {
-            mScrollWatcher.onScrollChanged(horiz, vert, oldHoriz, oldVert);
-        }
-    }
-
-    public void setContentSizeWatcher(ContentSizeWatcher contentSizeWatcher) {
-        mContentSizeWatcher = contentSizeWatcher;
-    }
-
-    private void onContentSizeChange() {
-        if (mContentSizeWatcher != null) {
-            mContentSizeWatcher.onLayout();
-        }
-
-        setIntrinsicContentSize();
-    }
-
-    @Override
-    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
-        onContentSizeChange();
-    }
-
-    private void setIntrinsicContentSize() {
-        ReactContext reactContext = (ReactContext) getContext();
-        UIManagerModule uiManager = reactContext.getNativeModule(UIManagerModule.class);
-        final ReactTextInputLocalData localData = new ReactTextInputLocalData(this);
-        uiManager.setViewLocalData(getId(), localData);
-    }
-
-    //// Text changed events
-
-    public int incrementAndGetEventCounter() {
-        return ++mNativeEventCount;
-    }
-
-    @Override
-    public void addTextChangedListener(TextWatcher watcher) {
-        if (mListeners == null) {
-            mListeners = new ArrayList<>();
-            super.addTextChangedListener(getTextWatcherDelegator());
-        }
-
-        mListeners.add(watcher);
-    }
-
-    @Override
-    public void removeTextChangedListener(TextWatcher watcher) {
-        if (mListeners != null) {
-            mListeners.remove(watcher);
-
-            if (mListeners.isEmpty()) {
-                mListeners = null;
-                super.removeTextChangedListener(getTextWatcherDelegator());
-            }
-        }
-    }
-
-    private TextWatcherDelegator getTextWatcherDelegator() {
-        if (mTextWatcherDelegator == null) {
-            mTextWatcherDelegator = new TextWatcherDelegator();
-        }
-        return mTextWatcherDelegator;
-    }
-
-    /**
-     * This class will redirect *TextChanged calls to the listeners only in the case where the text
-     * is changed by the user, and not explicitly set by JS.
-     */
-    private class TextWatcherDelegator implements TextWatcher {
-        @Override
-        public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-            if (!mIsSettingTextFromJS && mListeners != null) {
-                for (TextWatcher listener : mListeners) {
-                    listener.beforeTextChanged(s, start, count, after);
-                }
-            }
-        }
-
-        @Override
-        public void onTextChanged(CharSequence s, int start, int before, int count) {
-            if (!mIsSettingTextFromJS && mListeners != null) {
-                for (TextWatcher listener : mListeners) {
-                    listener.onTextChanged(s, start, before, count);
-                }
-            }
-
-            onContentSizeChange();
-        }
-
-        @Override
-        public void afterTextChanged(Editable s) {
-            if (!mIsSettingTextFromJS && mListeners != null) {
-                for (TextWatcher listener : mListeners) {
-                    listener.afterTextChanged(s);
-                }
-            }
-        }
+    public void setAztecText(ReactAztecText aztecText) {
+        this.aztecText = aztecText;
+        this.addView(aztecText);
     }
 }

--- a/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecView.java
+++ b/android/Application/src/main/java/com/example/android/ReactAztec/ReactAztecView.java
@@ -4,8 +4,13 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.widget.RelativeLayout;
 
+import org.wordpress.aztec.source.SourceViewEditText;
+import org.wordpress.aztec.toolbar.AztecToolbar;
+
 public class ReactAztecView extends RelativeLayout {
-    private ReactAztecText aztecText;
+    private ReactAztecText mAztecText;
+    private SourceViewEditText mSourceEditor;
+    private AztecToolbar mToolbar;
 
     public ReactAztecView(Context ctx) {
         super(ctx);
@@ -16,10 +21,26 @@ public class ReactAztecView extends RelativeLayout {
     }
 
     ReactAztecText getAztecText() {
-        return aztecText;
+        return mAztecText;
     }
 
     void setAztecText(ReactAztecText aztecText) {
-        this.aztecText = aztecText;
+        this.mAztecText = aztecText;
+    }
+
+    public SourceViewEditText getSourceEditor() {
+        return mSourceEditor;
+    }
+
+    public void setSourceEditor(SourceViewEditText mSourceEditor) {
+        this.mSourceEditor = mSourceEditor;
+    }
+
+    public AztecToolbar getToolbar() {
+        return mToolbar;
+    }
+
+    public void setToolbar(AztecToolbar mToolbar) {
+        this.mToolbar = mToolbar;
     }
 }

--- a/android/Application/src/main/java/com/example/android/ReactAztec/ReactaztecEndEditingEvent.java
+++ b/android/Application/src/main/java/com/example/android/ReactAztec/ReactaztecEndEditingEvent.java
@@ -9,13 +9,13 @@ import com.facebook.react.uimanager.events.RCTEventEmitter;
  * Event emitted by Aztec native view when text editing ends,
  * because of the user leaving the text input.
  */
-class ReactaztecEndEditingEvent extends Event<ReactaztecEndEditingEvent> {
+class ReactAztecEndEditingEvent extends Event<ReactAztecEndEditingEvent> {
 
   private static final String EVENT_NAME = "topEndEditing";
 
   private String mText;
 
-  public ReactaztecEndEditingEvent(
+  public ReactAztecEndEditingEvent(
       int viewId,
       String text) {
     super(viewId);

--- a/android/Application/src/main/res/layout/aztec_main.xml
+++ b/android/Application/src/main/res/layout/aztec_main.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<com.example.android.ReactAztec.ReactAztecView xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:aztec="http://schemas.android.com/apk/res-auto"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+    <org.wordpress.aztec.toolbar.AztecToolbar
+        android:id="@+id/formatting_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/aztec_format_bar_height"
+        android:layout_alignParentBottom="true">
+    </org.wordpress.aztec.toolbar.AztecToolbar>
+
+    <FrameLayout
+        android:layout_above="@+id/formatting_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" >
+
+        <com.example.android.ReactAztec.ReactAztecText
+            android:id="@+id/aztec"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="top|start"
+            android:hint="TEst"
+            android:paddingEnd="16dp"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            android:paddingTop="16dp"
+            android:scrollbars="vertical"
+            android:imeOptions="flagNoExtractUi"
+            aztec:historyEnable="true"
+            aztec:historySize="10"/>
+
+        <org.wordpress.aztec.source.SourceViewEditText
+            android:id="@+id/source"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="top|start"
+            android:hint="Test"
+            android:inputType="textNoSuggestions|textMultiLine"
+            android:paddingEnd="16dp"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            android:paddingTop="16dp"
+            android:scrollbars="vertical"
+            android:textSize="14sp"
+            android:visibility="gone"
+            android:imeOptions="flagNoExtractUi"
+            aztec:codeBackgroundColor="@android:color/transparent"
+            aztec:codeTextColor="@android:color/white"/>
+
+    </FrameLayout>
+</com.example.android.ReactAztec.ReactAztecView>

--- a/android/Application/src/main/res/layout/aztec_main.xml
+++ b/android/Application/src/main/res/layout/aztec_main.xml
@@ -22,13 +22,14 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="top|start"
-            android:hint="TEst"
+            android:hint="Test"
             android:paddingEnd="16dp"
             android:paddingLeft="16dp"
             android:paddingRight="16dp"
             android:paddingTop="16dp"
-            android:scrollbars="vertical"
             android:imeOptions="flagNoExtractUi"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
             aztec:historyEnable="true"
             aztec:historySize="10"/>
 
@@ -43,12 +44,13 @@
             android:paddingLeft="16dp"
             android:paddingRight="16dp"
             android:paddingTop="16dp"
-            android:scrollbars="vertical"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
             android:textSize="14sp"
             android:visibility="gone"
             android:imeOptions="flagNoExtractUi"
             aztec:codeBackgroundColor="@android:color/transparent"
-            aztec:codeTextColor="@android:color/white"/>
+            aztec:codeTextColor="@android:color/black"/>
 
     </FrameLayout>
 </com.example.android.ReactAztec.ReactAztecView>

--- a/android/Application/src/main/res/values/styles.xml
+++ b/android/Application/src/main/res/values/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+    <style name="AztecToolbarStyle">
+        <item name="advanced">false</item>
+        <item name="mediaToolbarAvailable">false</item>
+    </style>
+
+</resources>

--- a/index.js
+++ b/index.js
@@ -28,7 +28,6 @@ class AztecTextInput extends React.Component {
                          style={[styles.hello, {minHeight: myMinHeight}]}
                          text = {this.props.text}
                          onContentSizeChange= {(event) => {
-                         console.log(event.nativeEvent);
                               this.setState({height: event.nativeEvent.contentSize.height});
                           }}
                          color = {'black'}

--- a/index.js
+++ b/index.js
@@ -26,12 +26,9 @@ class AztecTextInput extends React.Component {
                     <RCTAztecView
                          {...this.props}
                          style={[styles.hello, {minHeight: myMinHeight}]}
-                         multiline={true}
                          text = {this.props.text}
-                         onScroll = {(event) => {
-                             console.log(event.nativeEvent);
-                         }}
                          onContentSizeChange= {(event) => {
+                         console.log(event.nativeEvent);
                               this.setState({height: event.nativeEvent.contentSize.height});
                           }}
                          color = {'black'}
@@ -50,7 +47,7 @@ var styles = StyleSheet.create({
     },
     hello: {
     margin: 10,
-    minHeight: 200,
+    minHeight: 400,
   },
 });
 

--- a/index.js
+++ b/index.js
@@ -2,14 +2,16 @@ import React, { Component } from 'react';
 import {AppRegistry, StyleSheet, View, FlatList} from 'react-native';
 import RCTAztecView from './AztecView';
 
+const _minHeight = 300;
+
 class AztecTextInput extends React.Component {
     constructor(props) {
         super(props);
-        this.state = {isShowingText: true, height: 200};
+        this.state = {isShowingText: true, height: _minHeight};
     }
 
     render() {
-        let myMinHeight = Math.max(200, this.state.height);
+        let myMinHeight = Math.max(_minHeight, this.state.height);
         return (
               <View style={styles.container}>
               <FlatList
@@ -25,7 +27,7 @@ class AztecTextInput extends React.Component {
                     renderItem={({item}) =>
                     <RCTAztecView
                          {...this.props}
-                         style={[styles.hello, {minHeight: myMinHeight}]}
+                         style={[styles.aztec_editor, {minHeight: myMinHeight}]}
                          text = {this.props.text}
                          onContentSizeChange= {(event) => {
                               this.setState({height: event.nativeEvent.contentSize.height});
@@ -41,12 +43,10 @@ class AztecTextInput extends React.Component {
 
 var styles = StyleSheet.create({
     container: {
-     flex: 1,
-     paddingTop: 22
+     flex: 1
     },
-    hello: {
-    margin: 10,
-    minHeight: 400,
+    aztec_editor: {
+    minHeight: _minHeight,
   },
 });
 


### PR DESCRIPTION
This is a kind of BIG refactoring PR, since I switched things upside down a bit.

Instead of exposing `AztecText` to React Native, i've decided to expose the main `Aztec` component altogether (that includes toolbar, and source editor). This way the Aztec code is self contained, and we don't need to get too crazy passing events between Java -> JS -> Java again for each simple changes in the toolbar and to be able to reuse as much as Aztec code as possible.

There are still lot of things to fix, but i'd like to see this PR merged first in `android-autogrow-direct-link-to-aztec`, and then merge it to master before starting fine tuning.

cc @mzorz 

