### PR TITLE
Issue/7 prepare for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "AztecReactNativeExampleApp",
+  "name": "react-native-aztec",
   "version": "0.0.1",
   "license": "GPL-2.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "AztecReactNativeExampleApp",
   "version": "0.0.1",
   "license": "GPL-2.0",
-  "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "watchman watch-del-all; rm -rf node_modules/ example/node_modules/ yarn.lock example/yarn.lock package-lock.json example/package-lock.json; rm -rf $TMPDIR/react-*; rm -rf $TMPDIR/metro-cache-*; rm -rf $TMPDIR/jest_*",


### PR DESCRIPTION
This PR does the minimum minor modifications in preparation for publishing to `npm` registry.
Was supposed to be a bigger thing but decided this is good enough for now, and didn't want to just discard the changes altogether (as we'd need to make them again in the future anyway).

As stated in the comment here https://github.com/wordpress-mobile/react-native-aztec/issues/7#issuecomment-382013764  I think we can defer the actual act of publishing to `npm` a bit ahead in time, once we have a better component (perhaps even including the iOS implementation).

cc @daniloercoli @maxme 