### PR TITLE
Improve package.json files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,20 +88,19 @@ Q: The example app gets compiled but ReactNative shows an error
 
 A: try running, from the root folder in the project
 ```
-cd example/
-yarn start --reset-cache
+$ cd example/
+$ yarn start --reset-cache
 ```
 
 Open a new shell window and run either of these depending on the platform:
 
 ```
-yarn android
-
+$ yarn android
 ```
 
 or
 
 ```
-yarn ios
+$ yarn ios
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,6 @@ If you have to change Android native code, you must have a look at the code in `
 
 ## Android: Run the example app
 
-At the root folder, run:
-```
-$ yarn clean:install
-```
-
 Make sure to have an emulator running or an Android device connected, and then:
 
 ```
@@ -67,18 +62,9 @@ This will build the Android library (via `gradle`) and example app, then launch 
 
 ## iOS: Run the example app
 
-At the root folder, clean the library:
-```
-$ yarn clean:install
-```
-
-Then move to the example folder:
+Simply do:
 ```
 $ cd example/
-```
-
-Clean the example app and run it:
-```
 $ yarn clean:install
 $ yarn ios
 ```
@@ -102,8 +88,6 @@ Q: The example app gets compiled but ReactNative shows an error
 
 A: try running, from the root folder in the project
 ```
-yarn clean
-yarn
 cd example/
 yarn start --reset-cache
 ```

--- a/example/package.json
+++ b/example/package.json
@@ -8,12 +8,11 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "test": "jest",
-    "clean": "watchman watch-del-all; rm -rf node_modules/ yarn.lock package-lock.json; yarn clean-react; yarn clean-metro; yarn clean-jest; yarn clean-ios;",
-    "clean-ios": "type xcodebuild &> /dev/null && (xcodebuild -project ./iOS/example.xcodeproj -alltargets clean && rm -rf ./iOS/build);",
-    "clean-jest": "rm -rf $TMPDIR/jest_*",
-    "clean-metro": "rm -rf $TMPDIR/metro-cache-*; rm -rf $TMPDIR/metro-bundler-cache-*;",
-    "clean-react": "rm -rf $TMPDIR/react-*; rm -rf $TMPDIR/react-native-packager-cache-*",
-    "clean:install": "yarn clean; yarn;"
+    "clean": "yarn clean-aztec; yarn clean-node; yarn clean-ios;",
+    "clean-aztec": "pushd ../ && (yarn clean; popd;)",
+    "clean-ios": "type xcodebuild &> /dev/null && (xcodebuild -project ./ios/example.xcodeproj -alltargets clean && rm -rf ./ios/build);",
+    "clean-node": "rm -rf node_modules/;",
+    "clean:install": "yarn clean && yarn install"
   },
   "dependencies": {
     "react": "16.3.1",

--- a/example/package.json
+++ b/example/package.json
@@ -4,6 +4,7 @@
   "description": "Example for running ponies",
   "main": "index.js",
   "scripts": {
+    "install-aztec": "pushd ../ && (yarn install; popd;)",
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
@@ -12,7 +13,7 @@
     "clean-aztec": "pushd ../ && (yarn clean; popd;)",
     "clean-ios": "type xcodebuild &> /dev/null && (xcodebuild -project ./ios/example.xcodeproj -alltargets clean && rm -rf ./ios/build);",
     "clean-node": "rm -rf node_modules/;",
-    "clean:install": "yarn clean && yarn install"
+    "clean:install": "yarn clean && yarn install-aztec && yarn install"
   },
   "dependencies": {
     "react": "16.3.1",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "version": "0.0.1",
   "license": "GPL-2.0",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "clean": "watchman watch-del-all; rm -rf node_modules/ yarn.lock package-lock.json; rm -rf $TMPDIR/react-*; rm -rf $TMPDIR/metro-cache-*; rm -rf $TMPDIR/jest_*",
-    "clean:install": "yarn clean; yarn; pushd example; yarn; popd"
+    "clean": "yarn clean-watchman; yarn clean-node; yarn clean-react; yarn clean-metro; yarn clean-jest;",
+    "clean-jest": "rm -rf $TMPDIR/jest_*;",
+    "clean-metro": "rm -rf $TMPDIR/metro-cache-*; rm -rf $TMPDIR/metro-bundler-cache-*;",
+    "clean-node": "rm -rf node_modules/;",
+    "clean-react": "rm -rf $TMPDIR/react-*; rm -rf $TMPDIR/react-native-packager-cache-*;",
+    "clean-watchman": "watchman watch-del-all;"
   },
   "peerDependencies": {
     "react": "16.3.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "clean-metro": "rm -rf $TMPDIR/metro-cache-*; rm -rf $TMPDIR/metro-bundler-cache-*;",
     "clean-node": "rm -rf node_modules/;",
     "clean-react": "rm -rf $TMPDIR/react-*; rm -rf $TMPDIR/react-native-packager-cache-*;",
-    "clean-watchman": "watchman watch-del-all;"
+    "clean-watchman": "watchman watch-del-all;",
+    "clean:install": "yarn clean && yarn install"
   },
   "peerDependencies": {
     "react": "16.3.1",


### PR DESCRIPTION
### Description

This PR proposes some improvements to our `package.json` files structure and usage.

### Details

These are the proposed changes:

- The clean scripts [no longer delete the `.lock` files for yarn and npm](https://github.com/wordpress-mobile/react-native-aztec/pull/13/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L7).  The `yarn` lockfile's purpose is explained in detail [here](https://yarnpkg.com/blog/2016/11/24/lockfiles-for-all/).  Erasing these files should not be part of the clean procedure, but rather part of an explicit and manual dependency update procedure.  In fact, when running `yarn upgrade` and `npm upgrade` these files are already deleted.
- I [separated the cleaning scripts by component](https://github.com/wordpress-mobile/react-native-aztec/pull/13/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R7), to group them and make them easier to maintain.  The rationale is that it'll be easier for us to check if a cleaning procedure needs an update if we can quickly visualize which tool "owns" it.
- The example app uses the library so it's natural for it to [include the library in its cleaning procedures](https://github.com/wordpress-mobile/react-native-aztec/pull/13/files#diff-012ac553d93d987b8d34ad013052bc96R12).  Especially because we'll often be building / running the library through the example app.  On the contrary, [the library doesn't know or care about the example App](https://github.com/wordpress-mobile/react-native-aztec/pull/13/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L8).
- Cleaning scripts are no longer duplicated between our two `package.json` files.  Whenever a cleaning script needs to be duplicated [it is now being forwarded to the base `package.json` file](https://github.com/wordpress-mobile/react-native-aztec/pull/13/files#diff-012ac553d93d987b8d34ad013052bc96R12).  This is simply to avoid duplicating code.
- [Unused / non-working scripts were removed](https://github.com/wordpress-mobile/react-native-aztec/pull/13/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L6) and can be added back once working.
- You'll notice a more specific usage of `;` vs `&&` in the scripts.
- [Simplified the documentation](https://github.com/wordpress-mobile/react-native-aztec/pull/13/files#diff-04c6e90faac2675aa89e2176d2eec7d8L53), since running the clean script from the example app is now enough.

### Possible improvements

We could remove the old [metro](https://github.com/wordpress-mobile/react-native-aztec/pull/13/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R8) and [RN cache](https://github.com/wordpress-mobile/react-native-aztec/pull/13/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R10) names.  Not sure about this.

### Testing

- Try doing `yarn clean` in both the main library and the example app.  Make sure the logs show the expected execution flow.
- `cd $TMPDIR` whenever you want to check the new cache file / folder names.