### PR TITLE
remove directory structure from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,48 +6,6 @@ Wrapping Aztec Android and Aztec iOS in a React Native component
 
 GPL v2
 
-
-## Directory structure
-
-```
-.
-├── example
-│   ├── android
-│   ├── ios
-│   ├── app.json
-│   ├── index.android.js
-│   ├── index.ios.js
-│   └── package.json
-├── android
-│   └── src
-│      └── main
-│          └── java
-│              └── org
-│                  └── wordpress
-│                      └── mobile
-│                          └── ReactNativeAztec
-│                              ├── ReactAztecBlurEvent.java
-│                              ├── ReactAztecEndEditingEvent.java
-│                              ├── ReactAztecFocusEvent.java
-│                              ├── ReactAztecManager.java
-│                              ├── ReactAztecPackage.java
-│                              ├── ReactAztecText.java
-│                              └── ReactAztecView.java
-├── src
-│   └── AztecView.js
-├── index.js
-├── ios
-│   ├── Frameworks
-│   ├── RNTAztecView
-│   │      └── RCTAztecView.m
-│   └── RNTAztecView.xcodeproj
-├── package.json
-├── LICENSE.md
-└── README.md
-```
-
-If you have to change Android native code, you must have a look at the code in `android/src/main/java/` folder.
-
 ## Android: Run the example app
 
 At the root folder, run:


### PR DESCRIPTION
Thanks for making this observation @diegoreymendez 🙇 

This PR removes the directory structure section from the README; that’s coming from me copying the README from https://github.com/wordpress-mobile/react-native-recyclerview-list repo, which is in turn a fork, and the changes there implied changing the folder structure, that’s why it was important in his PR to contribute to that other repo to have a description of the new structure, but it’s totally unneeded in the `react-native-aztec` repo.

cc @diegoreymendez @daniloercoli 