### PR TITLE
Add the ability to get the content in AztecRN from JS

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -146,16 +146,16 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
                         if (hasFocus) {
                             eventDispatcher.dispatchEvent(
                                     new ReactAztecFocusEvent(
-                                            aztecText.getId()));
+                                            editText.getId()));
                         } else {
                             eventDispatcher.dispatchEvent(
                                     new ReactAztecBlurEvent(
-                                            aztecText.getId()));
+                                            editText.getId()));
 
                             eventDispatcher.dispatchEvent(
                                     new ReactAztecEndEditingEvent(
-                                            aztecText.getId(),
-                                            editText.getText().toString()));
+                                            editText.getId(),
+                                            editText.toHtml(false)));
                         }
                     }
                 });

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -60,6 +60,11 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
                                 MapBuilder.of(
                                         "bubbled", "onSubmitEditing", "captured", "onSubmitEditingCapture")))*/
                 .put(
+                        "topChange",
+                        MapBuilder.of(
+                                "phasedRegistrationNames",
+                                MapBuilder.of("bubbled", "onChange")))
+                .put(
                         "topEndEditing",
                         MapBuilder.of(
                                 "phasedRegistrationNames",
@@ -198,7 +203,7 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
             mEventDispatcher.dispatchEvent(
                     new ReactTextChangedEvent(
                             mEditText.getId(),
-                            s.toString(),
+                            mEditText.toHtml(false),
                             mEditText.incrementAndGetEventCounter()));
 
             mEventDispatcher.dispatchEvent(
@@ -247,9 +252,9 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
                 // FIXME: Note the 2 hacks here
                 mEventDispatcher.dispatchEvent(
                         new ReactContentSizeChangedEvent(
-                                mReactAztecText.getId(), // Note the ID of the parent here ;)
-                                PixelUtil.toDIPFromPixel(contentWidth) + 48,
-                                PixelUtil.toDIPFromPixel(contentHeight) + 48));
+                                mReactAztecText.getId(),
+                                PixelUtil.toDIPFromPixel(contentWidth),
+                                PixelUtil.toDIPFromPixel(contentHeight)));
             }
         }
     }

--- a/example/App.js
+++ b/example/App.js
@@ -34,6 +34,7 @@ export default class example extends React.Component {
                          onContentSizeChange= {(event) => {
                               this.setState({height: event.nativeEvent.contentSize.height});
                           }}
+                         onChange= {(event) => console.log(event.nativeEvent) }
                          color = {'black'}
                          maxImagesWidth = {200} />
                     }

--- a/example/App.js
+++ b/example/App.js
@@ -35,6 +35,7 @@ export default class example extends React.Component {
                               this.setState({height: event.nativeEvent.contentSize.height});
                           }}
                          onChange= {(event) => console.log(event.nativeEvent) }
+                         onEndEditing= {(event) => console.log(event.nativeEvent) }
                          color = {'black'}
                          maxImagesWidth = {200} />
                     }


### PR DESCRIPTION
This PR adds the `onChange` method to JS that can be used to keep tracks of changes made to the  text in Aztec. Basically it's required to load the content from Aztec, and it seems this is the standard way of keeping tracks of component changes in RN.

In this PR i've basically implemented in AztecRN the default behaviour of the RN TextInput component `onChange` method.

I've also refreshed the demo app, that now `onChange` just print the whole text to the default log. 
Now sure how we're going to use this in the main app, but consider the following: 
- It's called each time the user press a key in Aztec (basically each time the text is changed into it)
- If you update the state the AztecRN component will be re-rendered. We may need to set a guard in place in the demo app, that check if the content is changed or not.


There re other ways of getting the content from a Component but those feel hack-ish since involve `ref`. 