### PR TITLE
Fix `Tried to enqueue runnable on already finished thread` issue on Android

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -1,7 +1,6 @@
 package org.wordpress.mobile.ReactNativeAztec;
 
 
-import android.content.Context;
 import android.graphics.Color;
 import android.support.annotation.Nullable;
 import android.text.Editable;
@@ -29,12 +28,6 @@ import java.util.Map;
 public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
     public static final String REACT_CLASS = "RCTAztecView";
-    private Context mCallerContext;
-
-    public ReactAztecManager(Context ctx) {
-        super();
-        this.mCallerContext = ctx;
-    }
 
     @Override
     public String getName() {
@@ -43,7 +36,7 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
     @Override
     protected ReactAztecText createViewInstance(ThemedReactContext reactContext) {
-        ReactAztecText aztecText = new ReactAztecText(reactContext, mCallerContext);
+        ReactAztecText aztecText = new ReactAztecText(reactContext);
         aztecText.setCalypsoMode(false);
 
         return aztecText;

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecPackage.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecPackage.java
@@ -15,7 +15,7 @@ public class ReactAztecPackage implements ReactPackage {
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         List<ViewManager> views = new ArrayList<>();
-        views.add(new ReactAztecManager(reactContext));
+        views.add(new ReactAztecManager());
         return views;
     }
 

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -1,6 +1,5 @@
 package org.wordpress.mobile.ReactNativeAztec;
 
-import android.content.Context;
 import android.support.annotation.Nullable;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -41,8 +40,8 @@ public class ReactAztecText extends AztecText {
     // check when it's used in EditText in RN. (maybe tests?)
     private int mNativeEventCount = 0;
 
-    public ReactAztecText(ThemedReactContext reactContext, Context context) {
-        super(context);
+    public ReactAztecText(ThemedReactContext reactContext) {
+        super(reactContext);
         this.setFocusableInTouchMode(true);
         this.setFocusable(true);
 
@@ -52,8 +51,8 @@ public class ReactAztecText extends AztecText {
         addPlugin(new VideoShortcodePlugin());
         addPlugin(new AudioShortcodePlugin());
         addPlugin(new CssUnderlinePlugin());
-        this.setImageGetter(new GlideImageLoader(context));
-        this.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(context));
+        this.setImageGetter(new GlideImageLoader(reactContext));
+        this.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(reactContext));
     }
 
     @Override


### PR DESCRIPTION
This PR fixes #20 by not keeping a reference to the original context, and instead uses the context passed by the RN framework when new instances of Aztec are needed.

To test:
- in the main folder `yarn clean` and `yarn install`
- go to `example` folder
- `yarn start`
- Launch the demo app in AS
- Hit `reload` from the developer menu. 

You should not see any errors like: `Tried to enqueue runnable on already finished thread`
