### PR TITLE
Fix a bug where the `mIsSettingTextFromJS` was never set correctly

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -87,7 +87,9 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
     @ReactProp(name = "text")
     public void setText(ReactAztecText view, String text) {
+        view.setIsSettingTextFromJS(true);
         view.fromHtml(text);
+        view.setIsSettingTextFromJS(false);
     }
 
     @ReactProp(name = "color")

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -140,6 +140,10 @@ public class ReactAztecText extends AztecText {
         return mTextWatcherDelegator;
     }
 
+    public void setIsSettingTextFromJS(boolean mIsSettingTextFromJS) {
+        this.mIsSettingTextFromJS = mIsSettingTextFromJS;
+    }
+
     /**
      * This class will redirect *TextChanged calls to the listeners only in the case where the text
      * is changed by the user, and not explicitly set by JS.


### PR DESCRIPTION
This small PR fixes a bug where the `mIsSettingTextFromJS` variable was never used, resulting in AztecRN events being emitted when we set text programatically.

`That flag was supposed to be true when we set the text of the EditText explicitly. In that case, no *TextChanged events should be triggered. This is less expensive than removing the text listeners and adding them back again after the text change is completed. `

I know you @mzorz mentioned that during our 1st code review. :D Now we know why it was there in TextInput...

