### PR TITLE
Fix delayed update and weird output when typing fast in AztecRN

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -9,6 +9,8 @@ import android.view.View;
 
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.SimpleViewManager;
@@ -86,9 +88,18 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
     }
 
     @ReactProp(name = "text")
-    public void setText(ReactAztecText view, String text) {
+    public void setText(ReactAztecText view, ReadableMap inputMap) {
         view.setIsSettingTextFromJS(true);
-        view.fromHtml(text);
+        if (!inputMap.hasKey("eventCount")) {
+            view.fromHtml(inputMap.getString("text"));
+        } else {
+            // Don't think there is necessity of this branch, but justin case we want to
+            // force a 2nd setText from JS side to Native, just set a high eventCount
+            int eventCount = inputMap.getInt("eventCount");
+            if (view.mNativeEventCount < eventCount) {
+                view.fromHtml(inputMap.getString("text"));
+            }
+        }
         view.setIsSettingTextFromJS(false);
     }
 

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -89,17 +89,21 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
     @ReactProp(name = "text")
     public void setText(ReactAztecText view, ReadableMap inputMap) {
-        view.setIsSettingTextFromJS(true);
         if (!inputMap.hasKey("eventCount")) {
-            view.fromHtml(inputMap.getString("text"));
+            setTextfromJS(view, inputMap.getString("text"));
         } else {
             // Don't think there is necessity of this branch, but justin case we want to
             // force a 2nd setText from JS side to Native, just set a high eventCount
             int eventCount = inputMap.getInt("eventCount");
             if (view.mNativeEventCount < eventCount) {
-                view.fromHtml(inputMap.getString("text"));
+                setTextfromJS(view, inputMap.getString("text"));
             }
         }
+    }
+
+    private void setTextfromJS(ReactAztecText view, String text) {
+        view.setIsSettingTextFromJS(true);
+        view.fromHtml(text);
         view.setIsSettingTextFromJS(false);
     }
 

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -38,7 +38,7 @@ public class ReactAztecText extends AztecText {
 
     // FIXME: Used in `incrementAndGetEventCounter` but never read. I guess we can get rid of it, but before this
     // check when it's used in EditText in RN. (maybe tests?)
-    private int mNativeEventCount = 0;
+    int mNativeEventCount = 0;
 
     public ReactAztecText(ThemedReactContext reactContext) {
         super(reactContext);

--- a/example/App.js
+++ b/example/App.js
@@ -30,7 +30,7 @@ export default class example extends React.Component {
                     <RCTAztecView
                          {...this.props}
                          style={[styles.aztec_editor, {minHeight: myMinHeight}]}
-                         text = {this.state.text}
+                         text = {{text: this.state.text}}
                          onContentSizeChange= {(event) => {
                               this.setState({height: event.nativeEvent.contentSize.height});
                           }}

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -4,7 +4,7 @@ import {requireNativeComponent, ViewPropTypes} from 'react-native';
 var aztex = {
   name: 'AztecView',
   propTypes: {
-    text: PropTypes.string,
+    text: PropTypes.object,
     color: PropTypes.string,
     maxImagesWidth: PropTypes.number,
     minImagesWidth: PropTypes.number,


### PR DESCRIPTION
This PR just check the already available `mNativeEventCount` variable, and decides if the Aztec instance needs to be updated or not by matching the value.

This was necessary since `Native -> JS -> Native` refresh was really downgrading performance on writing and also introducing errors on delete/write.

Not completely sure this is the correct way, but it's a way that seems to work fine.