### PR TITLE
Use the GB plugin to handle the GB comments for Android

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -20,6 +20,7 @@ import org.wordpress.aztec.plugins.IToolbarButton;
 import org.wordpress.aztec.plugins.shortcodes.AudioShortcodePlugin;
 import org.wordpress.aztec.plugins.shortcodes.CaptionShortcodePlugin;
 import org.wordpress.aztec.plugins.shortcodes.VideoShortcodePlugin;
+import org.wordpress.aztec.plugins.wpcomments.HiddenGutenbergPlugin;
 import org.wordpress.aztec.plugins.wpcomments.WordPressCommentsPlugin;
 import org.wordpress.aztec.plugins.wpcomments.toolbar.MoreToolbarButton;
 
@@ -50,6 +51,7 @@ public class ReactAztecText extends AztecText {
         addPlugin(new CaptionShortcodePlugin(this));
         addPlugin(new VideoShortcodePlugin());
         addPlugin(new AudioShortcodePlugin());
+        addPlugin(new HiddenGutenbergPlugin(this));
         addPlugin(new CssUnderlinePlugin());
         this.setImageGetter(new GlideImageLoader(reactContext));
         this.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(reactContext));


### PR DESCRIPTION
This PR updates the bootstrap configuration of Aztec to include the Gutenberg plugin so GB comments are handled properly by Aztec.

Even though we most probably won't be feeding Aztec with the full block markup+GB comments, the plugin makes sure Aztec stays as compatible to GB as possible. Also, this will enable us to do more testing of the compatibility, hopefully automated. 