### PR TITLE
Fixes an glitch due to contentSize refreshes during layout.

### DIFF
--- a/ios/RNTAztecView/RCTAztecView.swift
+++ b/ios/RNTAztecView/RCTAztecView.swift
@@ -4,17 +4,24 @@ import Foundation
 class RCTAztecView: Aztec.TextView {
     @objc var onContentSizeChange: RCTBubblingEventBlock? = nil
     
+    private var previousContentSize: CGSize = .zero
+    
     // MARK - View Height: Match to content height
 
-    override var contentSize: CGSize {
-        didSet {
-            contentSizeChanged()
-        }
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        updateContentSizeInRN()
     }
 
-    func contentSizeChanged() {
+    func updateContentSizeInRN() {
         let newSize = contentSize
         
+        guard previousContentSize != newSize else {
+            return
+        }
+        
+        previousContentSize = newSize
         updateHeightToMatch(newSize.height)
         
         guard let onContentSizeChange = onContentSizeChange else {


### PR DESCRIPTION
### Description:

This PR fixes an issue that was causing glitches when editing, due to the `contentSize` being refreshed multiple times, with non-final dimensions, during layout.

Fixes #30.

### Testing:

Just open the editor and type away!

