### PR TITLE
iOS: Improves the text view automatic sizing mechanism.

### DIFF
--- a/ios/RNTAztecView/RCTAztecView.swift
+++ b/ios/RNTAztecView/RCTAztecView.swift
@@ -7,7 +7,7 @@ class RCTAztecView: Aztec.TextView {
     private var previousContentSize: CGSize = .zero
     
     // MARK - View Height: Match to content height
-
+    
     override func layoutSubviews() {
         super.layoutSubviews()
         
@@ -15,25 +15,17 @@ class RCTAztecView: Aztec.TextView {
     }
 
     func updateContentSizeInRN() {
-        let newSize = contentSize
+        let newSize = sizeThatFits(frame.size)
         
-        guard previousContentSize != newSize else {
-            return
+        guard previousContentSize != newSize,
+            let onContentSizeChange = onContentSizeChange else {
+                return
         }
         
         previousContentSize = newSize
-        updateHeightToMatch(newSize.height)
-        
-        guard let onContentSizeChange = onContentSizeChange else {
-            return
-        }
         
         let body = packForRN(newSize, withName: "contentSize")
         onContentSizeChange(body)
-    }
-    
-    func updateHeightToMatch(_ newHeight: CGFloat) {
-        bounds = CGRect(origin: .zero, size: CGSize(width: frame.width, height: newHeight))
     }
     
     // MARK: - Native-to-RN Value Packing Logic

--- a/ios/RNTAztecView/RCTAztecViewManager.swift
+++ b/ios/RNTAztecView/RCTAztecViewManager.swift
@@ -24,7 +24,7 @@ public class RCTAztecViewManager: RCTViewManager {
             defaultParagraphStyle: .default,
             defaultMissingImage: UIImage())
         
-        view.isScrollEnabled = true
+        view.isScrollEnabled = false
         
         view.backgroundColor = .yellow
         view.text = "Hello world!"


### PR DESCRIPTION
### Description:

The automatic sizing mechanism we were using wasn't working well in `gutenberg-mobile`.  The approach in this PR is a bit cleaner, and allows us to disable the text view's `scrollingEnabled`, which is "safer" in a way.

Once merged, I'll integrate this into `gutenberg-mobile`.

### Testing:

Launch the example app and make sure the text view size is aligned with the content.

### Known issues:

The example app has a single state object in JS, so all cells share the same height, which can result in some weirdness.