### PR TITLE
iOS: Expose and wire onChange propType for Aztec.

### DIFF
--- a/ios/RNTAztecView/RCTAztecView.swift
+++ b/ios/RNTAztecView/RCTAztecView.swift
@@ -2,6 +2,7 @@ import Aztec
 import Foundation
 
 class RCTAztecView: Aztec.TextView {
+    @objc var onChange: RCTBubblingEventBlock? = nil
     @objc var onContentSizeChange: RCTBubblingEventBlock? = nil
     
     private var previousContentSize: CGSize = .zero
@@ -28,7 +29,31 @@ class RCTAztecView: Aztec.TextView {
         onContentSizeChange(body)
     }
     
+    // MARK: - Edits
+    
+    open override func insertText(_ text: String) {
+        super.insertText(text)
+        
+        if let onChange = onChange {
+            let text = packForRN(getHTML(), withName: "text")
+            onChange(text)
+        }
+    }
+    
+    open override func deleteBackward() {
+        super.deleteBackward()
+        
+        if let onChange = onChange {
+            let text = packForRN(getHTML(), withName: "text")
+            onChange(text)
+        }
+    }
+    
     // MARK: - Native-to-RN Value Packing Logic
+    
+    func packForRN(_ text: String, withName name: String) -> [AnyHashable: Any] {
+        return [name: text]
+    }
     
     func packForRN(_ size: CGSize, withName name: String) -> [AnyHashable: Any] {
         

--- a/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/ios/RNTAztecView/RCTAztecViewManager.m
@@ -7,5 +7,6 @@ RCT_EXPORT_MODULE(RCTAztecView)
 
 RCT_REMAP_VIEW_PROPERTY(text, contents, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(onContentSizeChange, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 
 @end

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -8,6 +8,7 @@ var aztex = {
     color: PropTypes.string,
     maxImagesWidth: PropTypes.number,
     minImagesWidth: PropTypes.number,
+    onChange: PropTypes.func,
     onContentSizeChange: PropTypes.func,
     onScroll: PropTypes.func,
     ...ViewPropTypes, // include the default view properties


### PR DESCRIPTION
Title has it.  This PR exposes the `onChange` `propType` for AztecView.  It also wires the event to the Aztec example App.

No changes should be needed in `gutenberg-mobile` to incorporate these changes, other than updating the `react-native-aztec` submodule.

### Details:

I've tested this change for Android too, and was able to execute the App correctly.  The Editor state is maintained as well although there are some styling issues for Aztec iOS that we'll sort out in a separate PR.

### Testing:

Run both the Android and iOS app and make sure everything works fine.