### PR TITLE
iOS dependencies are automatically resolved on 'yarn ios'.

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -4,9 +4,9 @@
   "description": "Example for running ponies",
   "main": "index.js",
   "scripts": {
-    "install-aztec": "pushd ../ && (yarn install; popd;)",
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "android": "react-native run-android",
+    "preios": "pushd ../ && (yarn install-aztec-ios; popd;)",
     "ios": "react-native run-ios",
     "test": "jest",
     "clean": "yarn clean-aztec; yarn clean-node; yarn clean-ios;",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "license": "GPL-2.0",
   "scripts": {
+    "install-aztec-ios": "pushd ./ios && (carthage bootstrap --platform iOS --cache-builds; popd;)",
     "clean": "yarn clean-watchman; yarn clean-node; yarn clean-react; yarn clean-metro; yarn clean-jest;",
     "clean-jest": "rm -rf $TMPDIR/jest_*;",
     "clean-metro": "rm -rf $TMPDIR/metro-cache-*; rm -rf $TMPDIR/metro-bundler-cache-*;",


### PR DESCRIPTION
### Descirption:

This PR adds scripts that will resolve the iOS dependencies when `yarn ios` is executed (as a "pre" step to it).

The dependency verification uses a cache, so on the second run this should be faster.

### Details:

The script added in this PR will also be used to automate dependency resolution in `mobile-gutenberg`.

### Testing:

Before testing make sure the Carthage dependencies are deleted.  Execute these commands from the root directory:

```
cd ios
rm -rf Carthage
```

That directory contains the downloaded Carthage dependencies, and contains the build cache, which is checked through hashing (AFAIK).  The steps above are enough to be able to test the process from scratch, if you need to.

Then execute the following commands:

```
cd example
yarn ios
```

You should see that execution takes a while, as Carthage is checking out the dependencies and building them in the `ios/Carthage` folder.  In fact, feel free to check it's there once `yarn ios` finishes.

Run `yarn ios` again and make sure the command runs faster, and the on-screen log shows this message:

```
*** Valid cache found for AztecEditor-iOS, skipping build
```

