### PR TITLE
Removes the test initialization values for Aztec iOS.

### DIFF
--- a/ios/RNTAztecView/RCTAztecViewManager.swift
+++ b/ios/RNTAztecView/RCTAztecViewManager.swift
@@ -25,10 +25,6 @@ public class RCTAztecViewManager: RCTViewManager {
             defaultMissingImage: UIImage())
         
         view.isScrollEnabled = false
-        
-        view.backgroundColor = .yellow
-        view.text = "Hello world!"
-        
         view.textAttachmentDelegate = attachmentDelegate
         view.registerAttachmentImageProvider(imageProvider)
         


### PR DESCRIPTION
When initially integrating Aztec into RN, we had configured an initial text value and a yellow background for debugging purposes.

This PR removes them.

### Testing:

Just launch the App normally and make sure Aztec doesn't have a yellow background, and it doesn't have an initial "Hello World!" text.