### PR TITLE
Add support for placeholder text

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -20,6 +20,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.views.scroll.ScrollEvent;
 import com.facebook.react.views.scroll.ScrollEventType;
+import com.facebook.react.views.text.DefaultStyleValuesUtil;
 import com.facebook.react.views.textinput.ReactContentSizeChangedEvent;
 import com.facebook.react.views.textinput.ReactTextChangedEvent;
 import com.facebook.react.views.textinput.ReactTextInputEvent;
@@ -115,6 +116,20 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
         } catch (IllegalArgumentException e) {
         }
         view.setTextColor(newColor);
+    }
+
+    @ReactProp(name = "placeholder")
+    public void setPlaceholder(ReactAztecText view, @Nullable String placeholder) {
+        view.setHint(placeholder);
+    }
+
+    @ReactProp(name = "placeholderTextColor", customType = "Color")
+    public void setPlaceholderTextColor(ReactAztecText view, @Nullable Integer color) {
+        if (color == null) {
+            view.setHintTextColor(DefaultStyleValuesUtil.getDefaultTextColorHint(view.getContext()));
+        } else {
+            view.setHintTextColor(color);
+        }
     }
 
     @ReactProp(name = "maxImagesWidth")

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -95,6 +95,17 @@ public class ReactAztecText extends AztecText {
         setIntrinsicContentSize();
     }
 
+    // After the text changes inside an EditText, TextView checks if a layout() has been requested.
+    // If it has, it will not scroll the text to the end of the new text inserted, but wait for the
+    // next layout() to be called. However, we do not perform a layout() after a requestLayout(), so
+    // we need to override isLayoutRequested to force EditText to scroll to the end of the new text
+    // immediately.
+    // TODO: t6408636 verify if we should schedule a layout after a View does a requestLayout()
+    @Override
+    public boolean isLayoutRequested() {
+        return false;
+    }
+
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         onContentSizeChange();

--- a/example/App.js
+++ b/example/App.js
@@ -31,6 +31,8 @@ export default class example extends React.Component {
                          {...this.props}
                          style={[styles.aztec_editor, {minHeight: myMinHeight}]}
                          text = {{text: this.state.text}}
+                         placeholder = {'This is the placeholder text'}
+                         placeholderTextColor = {'darkblue'} // See http://facebook.github.io/react-native/docs/colors
                          onContentSizeChange= {(event) => {
                               this.setState({height: event.nativeEvent.contentSize.height});
                           }}

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -5,6 +5,8 @@ var aztex = {
   name: 'AztecView',
   propTypes: {
     text: PropTypes.object,
+    placeholder: PropTypes.string,
+    placeholderTextColor: PropTypes.number,
     color: PropTypes.string,
     maxImagesWidth: PropTypes.number,
     minImagesWidth: PropTypes.number,


### PR DESCRIPTION
This PR adds support for placeholder text, and placeholder text color to Android.

Also short-circuited `isLayoutRequested` to always return false, since this hack is available in the default implementation of TextInput in RN, and we should also have it in our implementation. Note sure if it was needed, but at least, from what I've got and tested, it doesn't hurt on performance - actually it helps.