### PR TITLE
Add placeholder properties for iOS AztecView.

### DIFF
--- a/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/ios/RNTAztecView/RCTAztecViewManager.m
@@ -9,4 +9,7 @@ RCT_REMAP_VIEW_PROPERTY(text, contents, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(onContentSizeChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 
+RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
+RCT_EXPORT_VIEW_PROPERTY(placeholderTextColor, UIColor)
+
 @end


### PR DESCRIPTION
Has the title said this PR adds support on iOS for the placeholder attributes.

How to test:
 - Start the sample app on iOS
 - Check if you delete all the text from one of the AztecTextView you can see the placeholder text in blue.