### PR TITLE
Adds an onEnter callback to iOS.

### DIFF
--- a/example/editor.js
+++ b/example/editor.js
@@ -46,6 +46,7 @@ export default class Editor extends Component {
                 placeholderTextColor = {'lightgray'} // See http://facebook.github.io/react-native/docs/colors                
                 onContentSizeChange= { onContentSizeChange }
                 onChange= {(event) => console.log(event.nativeEvent) }
+                onEnter= {(event) => console.log("asta") }
                 onEndEditing= {(event) => console.log(event.nativeEvent) }
                 onActiveFormatsChange = { this.onActiveFormatsChange }
                 color = {'black'}

--- a/ios/RNTAztecView/RCTAztecView.swift
+++ b/ios/RNTAztecView/RCTAztecView.swift
@@ -4,6 +4,7 @@ import UIKit
 
 class RCTAztecView: Aztec.TextView {
     @objc var onChange: RCTBubblingEventBlock? = nil
+    @objc var onEnter: RCTBubblingEventBlock? = nil
     @objc var onContentSizeChange: RCTBubblingEventBlock? = nil
 
     @objc var onActiveFormatsChange: RCTBubblingEventBlock? = nil
@@ -61,8 +62,16 @@ class RCTAztecView: Aztec.TextView {
     // MARK: - Edits
     
     open override func insertText(_ text: String) {
+        guard text != "\n" else {
+            print("onEnter: \(String(describing: onEnter))")
+            
+            onEnter?([:])
+            return
+        }
+        
         super.insertText(text)
         updatePlaceholderVisibility()
+        
         if let onChange = onChange {
             let text = packForRN(getHTML(), withName: "text")
             onChange(text)
@@ -72,6 +81,7 @@ class RCTAztecView: Aztec.TextView {
     open override func deleteBackward() {
         super.deleteBackward()
         updatePlaceholderVisibility()
+        
         if let onChange = onChange {
             let text = packForRN(getHTML(), withName: "text")
             onChange(text)
@@ -81,7 +91,8 @@ class RCTAztecView: Aztec.TextView {
     // MARK: - Native-to-RN Value Packing Logic
     
     func packForRN(_ text: String, withName name: String) -> [AnyHashable: Any] {
-        return [name: text, "eventCount": 1]
+        return [name: text,
+                "eventCount": 1]
     }
     
     func packForRN(_ size: CGSize, withName name: String) -> [AnyHashable: Any] {

--- a/ios/RNTAztecView/RCTAztecView.swift
+++ b/ios/RNTAztecView/RCTAztecView.swift
@@ -62,9 +62,7 @@ class RCTAztecView: Aztec.TextView {
     // MARK: - Edits
     
     open override func insertText(_ text: String) {
-        guard text != "\n" else {
-            print("onEnter: \(String(describing: onEnter))")
-            
+        guard text != "\n" else {            
             onEnter?([:])
             return
         }

--- a/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/ios/RNTAztecView/RCTAztecViewManager.m
@@ -10,6 +10,7 @@ RCT_EXPORT_MODULE(RCTAztecView)
 RCT_REMAP_VIEW_PROPERTY(text, contents, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(onContentSizeChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onEnter, RCTBubblingEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(onActiveFormatsChange, RCTBubblingEventBlock)
 

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -13,6 +13,7 @@ class AztecView extends React.Component {
     minImagesWidth: PropTypes.number,
     onChange: PropTypes.func,
     onContentSizeChange: PropTypes.func,
+    onEnter: PropTypes.func,
     onScroll: PropTypes.func,
     onActiveFormatsChange: PropTypes.func,
     ...ViewPropTypes, // include the default view properties


### PR DESCRIPTION
Adds an onEnter callback to iOS.

This can be tested in `gutenberg-mobile`'s branch `try/enter-interception-ios`.

### Testing:

Check out the branch mentioned above.
Run the app.
Put the caret in the "Welcome to Gutenberg" text.
Press ENTER.
Make sure the debugger shows a console message each time it's pressed.