### PR TITLE
Improve propagation of change events

### DIFF
--- a/ios/RNTAztecView/RCTAztecView.swift
+++ b/ios/RNTAztecView/RCTAztecView.swift
@@ -69,17 +69,14 @@ class RCTAztecView: Aztec.TextView {
         
         super.insertText(text)
         updatePlaceholderVisibility()
-        
-        if let onChange = onChange {
-            let text = packForRN(getHTML(), withName: "text")
-            onChange(text)
-        }
     }
     
     open override func deleteBackward() {
         super.deleteBackward()
         updatePlaceholderVisibility()
-        
+    }
+
+    func propagateContentChanges() {
         if let onChange = onChange {
             let text = packForRN(getHTML(), withName: "text")
             onChange(text)
@@ -149,7 +146,6 @@ class RCTAztecView: Aztec.TextView {
         case "strikethrough": toggleStrikethrough(range: selectedRange)
         default: print("Format not recognized")
         }
-        propagateFormatChanges()
     }
 
     func propagateFormatChanges() {
@@ -179,6 +175,11 @@ extension RCTAztecView: UITextViewDelegate {
 
     func textViewDidChangeSelection(_ textView: UITextView) {
         propagateFormatChanges()
+    }
+
+    func textViewDidChange(_ textView: UITextView) {
+        propagateFormatChanges()
+        propagateContentChanges()
     }
 
 }

--- a/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/ios/RNTAztecView/RCTAztecViewManager.m
@@ -33,8 +33,7 @@ RCT_EXPORT_VIEW_PROPERTY(placeholderTextColor, UIColor)
 }
 
 RCT_EXPORT_METHOD(applyFormat:(nonnull NSNumber *)node format:(NSString *)format)
-{
-    RCTLogInfo(@"Apply format: %@", format);
+{    
     [self executeBlock:^(RCTAztecView *aztecView) {
         [aztecView applyWithFormat:format];
     } onNode:node];


### PR DESCRIPTION
This PR changes the way the propagation of onChange events is triggered on the RCTAztecView.

Instead of doing it on ```insertText``` and ```deleteBackward``` calls to the ```onChangeContent``` and ```onChangeFormats``` are now triggered on ```textViewDidChange``` delegate method.

This allows a more centralised place for updates and it also correct a bug where changes of format on text, like setting a word to bold, was not being propagated has a changeContent.

How to test:
 - Check that changes for the format of a word (like set to bold) in the content, cause onChange logs happening on the console.

