### PR TITLE
Adds a wrapper method for the onEnter callback.

### DIFF
--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -45,12 +45,22 @@ class AztecView extends React.Component {
     onContentSizeChange(size);
   }
 
+  _onEnter = (event) => {
+    if (!this.props.onEnter) {
+      return;
+    }
+
+    const { onEnter } = this.props;
+    onEnter();
+  }
+
   render() {
     const { onActiveFormatsChange, ...otherProps } = this.props    
     return (
       <RCTAztecView {...otherProps} 
         onActiveFormatsChange={ this._onActiveFormatsChange }
         onContentSizeChange = { this._onContentSizeChange }
+        onEnter = { this._onEnter }
       />
     );
   }


### PR DESCRIPTION
### Description:

Adds a wrapper method in the Aztec RN component to avoid passing the `event` object ahead.

Can be tested here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/136