### PR TITLE
Add on enter callback to Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,10 +77,10 @@ repositories {
 }
 
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:c955d9f5c8bb3ec8ed1b2f323f03445f77b14359')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:c955d9f5c8bb3ec8ed1b2f323f03445f77b14359')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:c955d9f5c8bb3ec8ed1b2f323f03445f77b14359')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:c955d9f5c8bb3ec8ed1b2f323f03445f77b14359')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:d3c0c815d6b67e0fdb1a105c47f7122297cbe178')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:d3c0c815d6b67e0fdb1a105c47f7122297cbe178')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:d3c0c815d6b67e0fdb1a105c47f7122297cbe178')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:d3c0c815d6b67e0fdb1a105c47f7122297cbe178')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecEnterEvent.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecEnterEvent.java
@@ -1,0 +1,39 @@
+package org.wordpress.mobile.ReactNativeAztec;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted by Aztec native view when KEYCODE_ENTER is detected.
+ */
+class ReactAztecEnterEvent extends Event<ReactAztecEnterEvent> {
+
+  private static final String EVENT_NAME = "topTextInputEnter";
+
+  public ReactAztecEnterEvent(int viewId) {
+    super(viewId);
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public boolean canCoalesce() {
+    return false;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  }
+
+  private WritableMap serializeEventData() {
+    WritableMap eventData = Arguments.createMap();
+    eventData.putInt("target", getViewTag());
+    return eventData;
+  }
+}

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -110,7 +110,7 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
     private void setTextfromJS(ReactAztecText view, String text) {
         view.setIsSettingTextFromJS(true);
-        view.fromHtml(text);
+        view.fromHtml(text, true);
         view.setIsSettingTextFromJS(false);
     }
 

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -77,6 +77,11 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
                                 "phasedRegistrationNames",
                                 MapBuilder.of("bubbled", "onTextInput", "captured", "onTextInputCapture")))
                 .put(
+                        "topTextInputEnter",
+                        MapBuilder.of(
+                                "phasedRegistrationNames",
+                                MapBuilder.of("bubbled", "onEnter")))
+                .put(
                         "topFocus",
                         MapBuilder.of(
                                 "phasedRegistrationNames",
@@ -167,6 +172,23 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
             view.setScrollWatcher(new AztecScrollWatcher(view));
         } else {
             view.setScrollWatcher(null);
+        }
+    }
+
+    @ReactProp(name = "onEnter", defaultBoolean = false)
+    public void setOnEnterHandling(final ReactAztecText view, boolean onEnterHandling) {
+        if (onEnterHandling) {
+            view.setOnEnterListener(new ReactAztecText.OnEnterListener() {
+                @Override
+                public boolean onEnterKey() {
+                    ReactContext reactContext = (ReactContext) view.getContext();
+                    EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+                    eventDispatcher.dispatchEvent(new ReactAztecEnterEvent(view.getId()));
+                    return true;
+                }
+            });
+        } else {
+            view.setOnEnterListener(null);
         }
     }
 


### PR DESCRIPTION
Add an onEnter callback to Android, and emit the proper event to JS.

Testing:
- Run the demo app
- Press ENTER

Make sure the debugger shows a console message each time it's pressed.

Note to @mzorz 
I've updated the Aztec-Android hashes to the latest version, that now includes those changes to `fromHtml(text, isInit);` to prevent hash calculation over the passed text when it's not the init phase. 
I've passed TRUE here even though it's not always true...  it should be fine since i'm going to disable history over AztecReactNative in Android, and don't think we will use the hash calculation here.