### PR TITLE
Add a new `returnHTMLWithCursor` command & returning event to the editor

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecHtmlWithCursorEvent.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecHtmlWithCursorEvent.java
@@ -1,0 +1,45 @@
+package org.wordpress.mobile.ReactNativeAztec;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted by AztecText native view when full content with cursor is requested by JS
+ */
+class ReactAztecHtmlWithCursorEvent extends Event<ReactAztecHtmlWithCursorEvent> {
+
+  private static final String EVENT_NAME = "topHTMLWithCursorRequested";
+
+  private String mText;
+
+  public ReactAztecHtmlWithCursorEvent(
+      int viewId,
+      String text) {
+    super(viewId);
+    mText = text;
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public boolean canCoalesce() {
+    return false;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  }
+
+  private WritableMap serializeEventData() {
+    WritableMap eventData = Arguments.createMap();
+    eventData.putInt("target", getViewTag());
+    eventData.putString("text", mText);
+    return eventData;
+  }
+}

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecHtmlWithCursorEvent.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecHtmlWithCursorEvent.java
@@ -13,12 +13,12 @@ class ReactAztecHtmlWithCursorEvent extends Event<ReactAztecHtmlWithCursorEvent>
   private static final String EVENT_NAME = "topHTMLWithCursorRequested";
 
   private String mText;
+  private int mCursorPosition;
 
-  public ReactAztecHtmlWithCursorEvent(
-      int viewId,
-      String text) {
+  public ReactAztecHtmlWithCursorEvent(int viewId, String text, int cursorPosition) {
     super(viewId);
     mText = text;
+    mCursorPosition = cursorPosition;
   }
 
   @Override
@@ -40,6 +40,7 @@ class ReactAztecHtmlWithCursorEvent extends Event<ReactAztecHtmlWithCursorEvent>
     WritableMap eventData = Arguments.createMap();
     eventData.putInt("target", getViewTag());
     eventData.putString("text", mText);
+    eventData.putInt("cursorPosition", mCursorPosition);
     return eventData;
   }
 }

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -82,6 +82,11 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
                                 "phasedRegistrationNames",
                                 MapBuilder.of("bubbled", "onEnter")))
                 .put(
+                        "topHTMLWithCursorRequested",
+                        MapBuilder.of(
+                                "phasedRegistrationNames",
+                                MapBuilder.of("bubbled", "onHTMLContentWithCursor")))
+                .put(
                         "topFocus",
                         MapBuilder.of(
                                 "phasedRegistrationNames",
@@ -193,11 +198,15 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
     }
 
     private static final int COMMAND_NOTIFY_APPLY_FORMAT = 1;
+    private static final int COMMAND_RETURN_HTML_WITH_CURSOR = 2;
     private static final String TAG = "ReactAztecText";
 
     @Override
     public Map<String, Integer> getCommandsMap() {
-        return MapBuilder.of("applyFormat", COMMAND_NOTIFY_APPLY_FORMAT);
+        return MapBuilder.<String, Integer>builder()
+                .put("applyFormat", COMMAND_NOTIFY_APPLY_FORMAT)
+                .put("returnHTMLWithCursor", COMMAND_RETURN_HTML_WITH_CURSOR)
+                .build();
     }
 
     @Override
@@ -209,6 +218,10 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
                 final String format = args.getString(0);
                 Log.d(TAG, String.format("Apply format: %s", format));
                 parent.applyFormat(format);
+                return;
+            }
+            case COMMAND_RETURN_HTML_WITH_CURSOR: {
+                parent.emitHTMLWithCursorEvent();
                 return;
             }
             default:

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -215,6 +215,15 @@ public class ReactAztecText extends AztecText {
         this.mIsSettingTextFromJS = mIsSettingTextFromJS;
     }
 
+    void emitHTMLWithCursorEvent() {
+        disableTextChangedListener();
+        String content = toPlainHtml(true);
+        enableTextChangedListener();
+        ReactContext reactContext = (ReactContext) getContext();
+        EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+        eventDispatcher.dispatchEvent(new ReactAztecHtmlWithCursorEvent( getId(), content));
+    }
+
     public void applyFormat(String format) {
         ArrayList<ITextFormat> newFormats = new ArrayList<>();
         switch (format) {

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -218,10 +218,16 @@ public class ReactAztecText extends AztecText {
     void emitHTMLWithCursorEvent() {
         disableTextChangedListener();
         String content = toPlainHtml(true);
+        int cursorPosition = content.indexOf("aztec_cursor");
+        if (cursorPosition != -1) {
+            content = content.replaceFirst("aztec_cursor", "");
+        } else {
+            cursorPosition = 0; // Something went wrong in Aztec - default to 0 if not found.
+        }
         enableTextChangedListener();
         ReactContext reactContext = (ReactContext) getContext();
         EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
-        eventDispatcher.dispatchEvent(new ReactAztecHtmlWithCursorEvent( getId(), content));
+        eventDispatcher.dispatchEvent(new ReactAztecHtmlWithCursorEvent( getId(), content, cursorPosition));
     }
 
     public void applyFormat(String format) {

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -67,10 +67,11 @@ class AztecView extends React.Component {
     if (!this.props.onHTMLContentWithCursor) {
       return;
     }
-
+    
+    const text = event.nativeEvent.text;
+    const cursorPosition = event.nativeEvent.cursorPosition;
     const { onHTMLContentWithCursor } = this.props;
-    const contentWithCursor = event.nativeEvent.text;
-    onHTMLContentWithCursor(contentWithCursor);
+    onHTMLContentWithCursor(text, cursorPosition);
   }
 
   render() {

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -16,6 +16,7 @@ class AztecView extends React.Component {
     onEnter: PropTypes.func,
     onScroll: PropTypes.func,
     onActiveFormatsChange: PropTypes.func,
+    onHTMLContentWithCursor: PropTypes.func,
     ...ViewPropTypes, // include the default view properties
   }
 
@@ -24,6 +25,14 @@ class AztecView extends React.Component {
                                           ReactNative.findNodeHandle(this),
                                           UIManager.RCTAztecView.Commands.applyFormat,
                                           [format],
+                                        );    
+  }
+
+  requestHTMLWithCursor() {
+    UIManager.dispatchViewManagerCommand(
+                                          ReactNative.findNodeHandle(this),
+                                          UIManager.RCTAztecView.Commands.returnHTMLWithCursor,
+                                          [],
                                         );    
   }
 
@@ -54,12 +63,23 @@ class AztecView extends React.Component {
     onEnter();
   }
 
+  _onHTMLContentWithCursor = (event) => {
+    if (!this.props.onHTMLContentWithCursor) {
+      return;
+    }
+
+    const { onHTMLContentWithCursor } = this.props;
+    const contentWithCursor = event.nativeEvent.text;
+    onHTMLContentWithCursor(contentWithCursor);
+  }
+
   render() {
     const { onActiveFormatsChange, ...otherProps } = this.props    
     return (
       <RCTAztecView {...otherProps} 
         onActiveFormatsChange={ this._onActiveFormatsChange }
         onContentSizeChange = { this._onContentSizeChange }
+        onHTMLContentWithCursor = { this._onHTMLContentWithCursor }
         onEnter = { this._onEnter }
       />
     );


### PR DESCRIPTION
This PR adds a new command `returnHTMLWithCursor` to the editor that emits a new event with HTML content and cursor  in it. 

This new event is mapped JS side to `onHTMLContentWithCursor`. 

Please do not merge this PR since its underlying logic still need to be discussed and approved.
