### PR TITLE
Fix missing styling - Send back to JS the HTML content after a styling command

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -9,6 +9,7 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.views.textinput.ContentSizeWatcher;
+import com.facebook.react.views.textinput.ReactTextChangedEvent;
 import com.facebook.react.views.textinput.ReactTextInputLocalData;
 import com.facebook.react.views.textinput.ScrollWatcher;
 
@@ -261,6 +262,16 @@ public class ReactAztecText extends AztecText {
             // Update the toolbar state
             updateToolbarButtons(getSelectionStart(), getSelectionEnd());
         }
+
+        // emit onChange because the underlying HTML has changed applying the style
+        ReactContext reactContext = (ReactContext) getContext();
+        EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+        eventDispatcher.dispatchEvent(
+                new ReactTextChangedEvent(
+                        getId(),
+                        toHtml(false),
+                        incrementAndGetEventCounter())
+        );
     }
 
     // Removes all formats in the list but if none found, applies the first one


### PR DESCRIPTION
This PR fixes an issue we're experiencing in `gb-mobile` where switching to the HTML view, and back to the visual editor, immediately after a styling command lost the last applied style.

Steps to reproduce the problem:
- Select some text (use an emulator and shift + arrow to select)
- Press Bold
- Switch to the HTML view and back to the visual editor (don’t write anything)
- See that bold is not applied

The fix in this PR is necessary since if you apply a style and then switch to the `HTML view`, or do nothing else in the editor, the new underlying HTML content was not propagated back to the JS side.