### PR TITLE
Return current selection instead of simple cursor position when hitting Enter

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecHtmlWithCursorEvent.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecHtmlWithCursorEvent.java
@@ -13,12 +13,14 @@ class ReactAztecHtmlWithCursorEvent extends Event<ReactAztecHtmlWithCursorEvent>
   private static final String EVENT_NAME = "topHTMLWithCursorRequested";
 
   private String mText;
-  private int mCursorPosition;
+  private int mSelectionStart;
+  private int mSelectionEnd;
 
-  public ReactAztecHtmlWithCursorEvent(int viewId, String text, int cursorPosition) {
+  public ReactAztecHtmlWithCursorEvent(int viewId, String text, int selectionStart, int selectionEnd) {
     super(viewId);
     mText = text;
-    mCursorPosition = cursorPosition;
+    mSelectionStart = selectionStart;
+    mSelectionEnd = selectionEnd;
   }
 
   @Override
@@ -40,7 +42,8 @@ class ReactAztecHtmlWithCursorEvent extends Event<ReactAztecHtmlWithCursorEvent>
     WritableMap eventData = Arguments.createMap();
     eventData.putInt("target", getViewTag());
     eventData.putString("text", mText);
-    eventData.putInt("cursorPosition", mCursorPosition);
+    eventData.putInt("selectionStart", mSelectionStart);
+    eventData.putInt("selectionEnd", mSelectionEnd);
     return eventData;
   }
 }

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -2,6 +2,8 @@ package org.wordpress.mobile.ReactNativeAztec;
 
 import android.support.annotation.Nullable;
 import android.text.Editable;
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
 import android.text.TextWatcher;
 
 import com.facebook.react.bridge.ReactContext;
@@ -12,6 +14,7 @@ import com.facebook.react.views.textinput.ContentSizeWatcher;
 import com.facebook.react.views.textinput.ReactTextInputLocalData;
 import com.facebook.react.views.textinput.ScrollWatcher;
 
+import org.wordpress.aztec.AztecParser;
 import org.wordpress.aztec.AztecText;
 import org.wordpress.aztec.AztecTextFormat;
 import org.wordpress.aztec.ITextFormat;
@@ -26,6 +29,9 @@ import org.wordpress.aztec.plugins.shortcodes.VideoShortcodePlugin;
 import org.wordpress.aztec.plugins.wpcomments.HiddenGutenbergPlugin;
 import org.wordpress.aztec.plugins.wpcomments.WordPressCommentsPlugin;
 import org.wordpress.aztec.plugins.wpcomments.toolbar.MoreToolbarButton;
+import org.wordpress.aztec.source.Format;
+import org.wordpress.aztec.spans.AztecCursorSpan;
+import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -217,17 +223,42 @@ public class ReactAztecText extends AztecText {
 
     void emitHTMLWithCursorEvent() {
         disableTextChangedListener();
-        String content = toPlainHtml(true);
-        int cursorPosition = content.indexOf("aztec_cursor");
-        if (cursorPosition != -1) {
-            content = content.replaceFirst("aztec_cursor", "");
-        } else {
-            cursorPosition = 0; // Something went wrong in Aztec - default to 0 if not found.
+        // The code below is taken from `toHtml` method of Aztec and adapted to report the current
+        // selection if present by adding 2 cursor spans before the converting to HTML.
+        AztecParser aztecParser = new AztecParser(getPlugins());
+        SpannableStringBuilder output = new SpannableStringBuilder(getText());
+        clearMetaSpans(output);
+        final AztecCursorSpan[] spans = output.getSpans(0, output.length(), AztecCursorSpan.class);
+        for (AztecCursorSpan currentSpan : spans) {
+            output.removeSpan(currentSpan);
         }
+
+        output.setSpan(new AztecCursorSpan(), getSelectionEnd(), getSelectionEnd(), Spanned.SPAN_MARK_MARK);
+        if (isTextSelected()) {
+            output.setSpan(new AztecCursorSpan(), getSelectionStart(), getSelectionStart(), Spanned.SPAN_MARK_MARK);
+        }
+
+        aztecParser.syncVisualNewlinesOfBlockElements(output);
+        Format.postProcessSpannedText(output, false);
+        String content = EndOfBufferMarkerAdder.removeEndOfTextMarker(aztecParser.toHtml(output, true));
+
+        int cursorPositionStart = content.indexOf("aztec_cursor");
+        if (cursorPositionStart != -1) {
+            content = content.replaceFirst("aztec_cursor", "");
+        }
+        int cursorPositionEnd = cursorPositionStart;
+
+        if (content.contains("aztec_cursor")) {
+            cursorPositionEnd = content.indexOf("aztec_cursor");
+            content = content.replaceFirst("aztec_cursor", "");
+        }
+
         enableTextChangedListener();
         ReactContext reactContext = (ReactContext) getContext();
         EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
-        eventDispatcher.dispatchEvent(new ReactAztecHtmlWithCursorEvent( getId(), content, cursorPosition));
+        eventDispatcher.dispatchEvent(
+                new ReactAztecHtmlWithCursorEvent(getId(), content, cursorPositionStart, cursorPositionEnd)
+        );
     }
 
     public void applyFormat(String format) {

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -69,9 +69,10 @@ class AztecView extends React.Component {
     }
     
     const text = event.nativeEvent.text;
-    const cursorPosition = event.nativeEvent.cursorPosition;
+    const selectionStart = event.nativeEvent.selectionStart;
+    const selectionEnd = event.nativeEvent.selectionEnd;
     const { onHTMLContentWithCursor } = this.props;
-    onHTMLContentWithCursor(text, cursorPosition);
+    onHTMLContentWithCursor(text, selectionStart, selectionEnd);
   }
 
   render() {


### PR DESCRIPTION
In order to properly communicate to the JS side the current editor selection, when the user hit Enter.Key, we've modified our previsions approach of returning HTML + cursor position code by adding the selection details to the event.

This PR does introduce a customized version of `toHtml` method, available in Aztec Android, and reports the current selection together with the HTML content to JS side.

Android Testing:
To test it, add a `console.log` in `AztecView.js-->_onHTMLContentWithCursor` method and verify that the selection passed back to JS is correct. 