### PR TITLE
Disable Aztec plugins by default since we don't need them on GB mobile

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -166,6 +166,18 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
         view.setMinImagesWidth(minWidth);
     }
 
+    /*
+     * This property/method is used to disable the Gutenberg compatibility mode on AztecRN.
+     *
+     * Aztec comes along with some nice plugins that are able to show preview of Pictures/Videos/shortcodes,
+     * and WP specific features, in the visual editor.
+     *
+     * We don't need those improvements in Gutenberg mobile, so this RN wrapper around Aztec
+     * that's only used in GB-mobile at the moment, does have them OFF by default.
+     *
+     * An external 3rd party RN-app can use AztecRN wrapper and set the `disableGutenbergMode` to false to have a fully
+     * working visual editor. See the demo app, where `disableGutenbergMode` is already OFF.
+     */
     @ReactProp(name = "disableGutenbergMode", defaultBoolean = false)
     public void disableGBMode(final ReactAztecText view, boolean disable) {
         if (disable) {

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -27,6 +27,16 @@ import com.facebook.react.views.textinput.ReactTextChangedEvent;
 import com.facebook.react.views.textinput.ReactTextInputEvent;
 import com.facebook.react.views.textinput.ScrollWatcher;
 
+import org.wordpress.aztec.glideloader.GlideImageLoader;
+import org.wordpress.aztec.glideloader.GlideVideoThumbnailLoader;
+import org.wordpress.aztec.plugins.CssUnderlinePlugin;
+import org.wordpress.aztec.plugins.shortcodes.AudioShortcodePlugin;
+import org.wordpress.aztec.plugins.shortcodes.CaptionShortcodePlugin;
+import org.wordpress.aztec.plugins.shortcodes.VideoShortcodePlugin;
+import org.wordpress.aztec.plugins.wpcomments.HiddenGutenbergPlugin;
+import org.wordpress.aztec.plugins.wpcomments.WordPressCommentsPlugin;
+import org.wordpress.aztec.plugins.wpcomments.toolbar.MoreToolbarButton;
+
 import java.util.Map;
 
 public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
@@ -42,7 +52,6 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
     protected ReactAztecText createViewInstance(ThemedReactContext reactContext) {
         ReactAztecText aztecText = new ReactAztecText(reactContext);
         aztecText.setCalypsoMode(false);
-
         return aztecText;
     }
 
@@ -155,6 +164,21 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
     @ReactProp(name = "minImagesWidth")
     public void setMinImagesWidth(ReactAztecText view, int minWidth) {
         view.setMinImagesWidth(minWidth);
+    }
+
+    @ReactProp(name = "disableGutenbergMode", defaultBoolean = false)
+    public void disableGBMode(final ReactAztecText view, boolean disable) {
+        if (disable) {
+            view.addPlugin(new WordPressCommentsPlugin(view));
+            view.addPlugin(new MoreToolbarButton(view));
+            view.addPlugin(new CaptionShortcodePlugin(view));
+            view.addPlugin(new VideoShortcodePlugin());
+            view.addPlugin(new AudioShortcodePlugin());
+            view.addPlugin(new HiddenGutenbergPlugin(view));
+            view.addPlugin(new CssUnderlinePlugin());
+            view.setImageGetter(new GlideImageLoader(view.getContext()));
+            view.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(view.getContext()));
+        }
     }
 
     @ReactProp(name = "onContentSizeChange", defaultBoolean = false)

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -178,6 +178,9 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
             view.addPlugin(new CssUnderlinePlugin());
             view.setImageGetter(new GlideImageLoader(view.getContext()));
             view.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(view.getContext()));
+            // we need to restart the editor now
+            String content = view.toHtml(false);
+            view.fromHtml(content, false);
         }
     }
 

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -19,17 +19,8 @@ import org.wordpress.aztec.AztecParser;
 import org.wordpress.aztec.AztecText;
 import org.wordpress.aztec.AztecTextFormat;
 import org.wordpress.aztec.ITextFormat;
-import org.wordpress.aztec.glideloader.GlideImageLoader;
-import org.wordpress.aztec.glideloader.GlideVideoThumbnailLoader;
-import org.wordpress.aztec.plugins.CssUnderlinePlugin;
 import org.wordpress.aztec.plugins.IAztecPlugin;
 import org.wordpress.aztec.plugins.IToolbarButton;
-import org.wordpress.aztec.plugins.shortcodes.AudioShortcodePlugin;
-import org.wordpress.aztec.plugins.shortcodes.CaptionShortcodePlugin;
-import org.wordpress.aztec.plugins.shortcodes.VideoShortcodePlugin;
-import org.wordpress.aztec.plugins.wpcomments.HiddenGutenbergPlugin;
-import org.wordpress.aztec.plugins.wpcomments.WordPressCommentsPlugin;
-import org.wordpress.aztec.plugins.wpcomments.toolbar.MoreToolbarButton;
 import org.wordpress.aztec.source.Format;
 import org.wordpress.aztec.spans.AztecCursorSpan;
 import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder;
@@ -58,16 +49,6 @@ public class ReactAztecText extends AztecText {
         super(reactContext);
         this.setFocusableInTouchMode(true);
         this.setFocusable(true);
-
-        addPlugin(new WordPressCommentsPlugin(this));
-        addPlugin(new MoreToolbarButton(this));
-        addPlugin(new CaptionShortcodePlugin(this));
-        addPlugin(new VideoShortcodePlugin());
-        addPlugin(new AudioShortcodePlugin());
-        addPlugin(new HiddenGutenbergPlugin(this));
-        addPlugin(new CssUnderlinePlugin());
-        this.setImageGetter(new GlideImageLoader(reactContext));
-        this.setVideoThumbnailGetter(new GlideVideoThumbnailLoader(reactContext));
     }
 
     @Override
@@ -76,7 +57,7 @@ public class ReactAztecText extends AztecText {
         onContentSizeChange();
     }
 
-    private void addPlugin(IAztecPlugin plugin) {
+    void addPlugin(IAztecPlugin plugin) {
         super.getPlugins().add(plugin);
         if (plugin instanceof IToolbarButton && getToolbar() != null ) {
             getToolbar().addButton((IToolbarButton)plugin);

--- a/example/editor.js
+++ b/example/editor.js
@@ -40,6 +40,7 @@ export default class Editor extends Component {
               </View>
               <AztecView
                 ref="_aztec"
+                disableGutenbergMode = { false }
                 style={[styles.aztec_editor, {minHeight: myMinHeight}]}
                 text = { { text: item.text } } 
                 placeholder = {'This is the placeholder text'}

--- a/example/editor.js
+++ b/example/editor.js
@@ -40,9 +40,9 @@ export default class Editor extends Component {
               </View>
               <AztecView
                 ref="_aztec"
-                disableGutenbergMode = { false }
                 style={[styles.aztec_editor, {minHeight: myMinHeight}]}
                 text = { { text: item.text } } 
+                disableGutenbergMode = { true }
                 placeholder = {'This is the placeholder text'}
                 placeholderTextColor = {'lightgray'} // See http://facebook.github.io/react-native/docs/colors                
                 onContentSizeChange= { onContentSizeChange }

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -5,6 +5,7 @@ import ReactNative, {requireNativeComponent, ViewPropTypes, UIManager, ColorProp
 class AztecView extends React.Component {
   
   static propTypes = {
+    disableGutenbergMode: PropTypes.bool, // if used, must be before 'text' prop
     text: PropTypes.object,
     placeholder: PropTypes.string,
     placeholderTextColor: ColorPropType,

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -5,7 +5,7 @@ import ReactNative, {requireNativeComponent, ViewPropTypes, UIManager, ColorProp
 class AztecView extends React.Component {
   
   static propTypes = {
-    disableGutenbergMode: PropTypes.bool, // if used, must be before 'text' prop
+    disableGutenbergMode: PropTypes.bool,
     text: PropTypes.object,
     placeholder: PropTypes.string,
     placeholderTextColor: ColorPropType,


### PR DESCRIPTION
This PR disables Aztec "default" plugins (shortcodes, pictures, videos, comments, etc) by default since we don't need them on GB mobile. Added a prop to bring them back, if someone wanted to use this wrapper in another RN project.

This is  just a quick hack, there no way to add plugins on demand at the moment, and probably we will not add this feature later.