### PR TITLE
Adds the mechanisms we need to provide HTML with cursor to JS.

### DIFF
--- a/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/ios/RNTAztecView/RCTAztecViewManager.m
@@ -13,6 +13,7 @@ RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onEnter, RCTBubblingEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(onActiveFormatsChange, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onHTMLContentWithCursor, RCTBubblingEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(placeholderTextColor, UIColor)
@@ -36,6 +37,13 @@ RCT_EXPORT_METHOD(applyFormat:(nonnull NSNumber *)node format:(NSString *)format
 {    
     [self executeBlock:^(RCTAztecView *aztecView) {
         [aztecView applyWithFormat:format];
+    } onNode:node];
+}
+
+RCT_EXPORT_METHOD(returnHTMLWithCursor:(nonnull NSNumber *)node)
+{
+    [self executeBlock:^(RCTAztecView *aztecView) {
+        [aztecView returnHTMLWithCursor];
     } onNode:node];
 }
 


### PR DESCRIPTION
Brings ENTER > split up to date with Android.

I recommend to test this through https://github.com/wordpress-mobile/gutenberg-mobile/pull/177