### PR TITLE
Add backspace pressed event to Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,10 +77,10 @@ repositories {
 }
 
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:1be976ab842b1e91c6f73679495121e1db7afef0')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:1be976ab842b1e91c6f73679495121e1db7afef0')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:1be976ab842b1e91c6f73679495121e1db7afef0')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:1be976ab842b1e91c6f73679495121e1db7afef0')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:fd5c5ce33eebf9673f50042a77986026e33fc086')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:fd5c5ce33eebf9673f50042a77986026e33fc086')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:fd5c5ce33eebf9673f50042a77986026e33fc086')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:fd5c5ce33eebf9673f50042a77986026e33fc086')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,10 +77,10 @@ repositories {
 }
 
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:dadd1770f31ddb98cb81b66bc19ab441a93150b8')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:dadd1770f31ddb98cb81b66bc19ab441a93150b8')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:dadd1770f31ddb98cb81b66bc19ab441a93150b8')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:dadd1770f31ddb98cb81b66bc19ab441a93150b8')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:1be976ab842b1e91c6f73679495121e1db7afef0')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:1be976ab842b1e91c6f73679495121e1db7afef0')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:1be976ab842b1e91c6f73679495121e1db7afef0')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:1be976ab842b1e91c6f73679495121e1db7afef0')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,10 +77,10 @@ repositories {
 }
 
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:d3c0c815d6b67e0fdb1a105c47f7122297cbe178')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:d3c0c815d6b67e0fdb1a105c47f7122297cbe178')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:d3c0c815d6b67e0fdb1a105c47f7122297cbe178')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:d3c0c815d6b67e0fdb1a105c47f7122297cbe178')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:8b3562785108879c894aa5f3e4439e0733230a61')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:8b3562785108879c894aa5f3e4439e0733230a61')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:8b3562785108879c894aa5f3e4439e0733230a61')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:8b3562785108879c894aa5f3e4439e0733230a61')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,10 +77,10 @@ repositories {
 }
 
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:8b3562785108879c894aa5f3e4439e0733230a61')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:8b3562785108879c894aa5f3e4439e0733230a61')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:8b3562785108879c894aa5f3e4439e0733230a61')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:8b3562785108879c894aa5f3e4439e0733230a61')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:dadd1770f31ddb98cb81b66bc19ab441a93150b8')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:dadd1770f31ddb98cb81b66bc19ab441a93150b8')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:dadd1770f31ddb98cb81b66bc19ab441a93150b8')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:dadd1770f31ddb98cb81b66bc19ab441a93150b8')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecBackSpaceEvent.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecBackSpaceEvent.java
@@ -1,0 +1,49 @@
+package org.wordpress.mobile.ReactNativeAztec;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted by Aztec native view when BackSpace is detected.
+ */
+class ReactAztecBackSpaceEvent extends Event<ReactAztecBackSpaceEvent> {
+
+  private static final String EVENT_NAME = "topTextInputBackspace";
+
+  private String mText;
+  private int mSelectionStart;
+  private int mSelectionEnd;
+
+  public ReactAztecBackSpaceEvent(int viewId, String text, int selectionStart, int selectionEnd) {
+    super(viewId);
+    mText = text;
+    mSelectionStart = selectionStart;
+    mSelectionEnd = selectionEnd;
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public boolean canCoalesce() {
+    return false;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  }
+
+  private WritableMap serializeEventData() {
+    WritableMap eventData = Arguments.createMap();
+    eventData.putInt("target", getViewTag());
+    eventData.putString("text", mText);
+    eventData.putInt("selectionStart", mSelectionStart);
+    eventData.putInt("selectionEnd", mSelectionEnd);
+    return eventData;
+  }
+}

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecBackSpaceEvent.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecBackSpaceEvent.java
@@ -6,9 +6,9 @@ import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 /**
- * Event emitted by Aztec native view when BackSpace is detected.
+ * Event emitted by Aztec native view when Backspace is detected.
  */
-class ReactAztecBackSpaceEvent extends Event<ReactAztecBackSpaceEvent> {
+class ReactAztecBackspaceEvent extends Event<ReactAztecBackspaceEvent> {
 
   private static final String EVENT_NAME = "topTextInputBackspace";
 
@@ -16,7 +16,7 @@ class ReactAztecBackSpaceEvent extends Event<ReactAztecBackSpaceEvent> {
   private int mSelectionStart;
   private int mSelectionEnd;
 
-  public ReactAztecBackSpaceEvent(int viewId, String text, int selectionStart, int selectionEnd) {
+  public ReactAztecBackspaceEvent(int viewId, String text, int selectionStart, int selectionEnd) {
     super(viewId);
     mText = text;
     mSelectionStart = selectionStart;

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -51,6 +51,8 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
     @Override
     protected ReactAztecText createViewInstance(ThemedReactContext reactContext) {
         ReactAztecText aztecText = new ReactAztecText(reactContext);
+        aztecText.setFocusableInTouchMode(true);
+        aztecText.setFocusable(true);
         aztecText.setCalypsoMode(false);
         return aztecText;
     }
@@ -90,6 +92,11 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
                         MapBuilder.of(
                                 "phasedRegistrationNames",
                                 MapBuilder.of("bubbled", "onEnter")))
+                .put(
+                        "topTextInputBackspace",
+                        MapBuilder.of(
+                                "phasedRegistrationNames",
+                                MapBuilder.of("bubbled", "onBackspace")))
                 .put(
                         "topFocus",
                         MapBuilder.of(
@@ -216,17 +223,12 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
     @ReactProp(name = "onEnter", defaultBoolean = false)
     public void setOnEnterHandling(final ReactAztecText view, boolean onEnterHandling) {
-        if (onEnterHandling) {
-            view.setOnEnterListener(new ReactAztecText.OnEnterListener() {
-                @Override
-                public boolean onEnterKey() {
-                    view.onEnter();
-                    return true;
-                }
-            });
-        } else {
-            view.setOnEnterListener(null);
-        }
+        view.shouldHandleOnEnter = onEnterHandling;
+    }
+
+    @ReactProp(name = "onBackspace", defaultBoolean = false)
+    public void setOnBackspaceHandling(final ReactAztecText view, boolean onBackspaceHandling) {
+        view.shouldHandleOnBackspace = onBackspaceHandling;
     }
 
     private static final int COMMAND_NOTIFY_APPLY_FORMAT = 1;

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -44,11 +44,28 @@ public class ReactAztecText extends AztecText {
     int mNativeEventCount = 0;
 
     String lastSentFormattingOptionsEventString = "";
+    boolean shouldHandleOnEnter = false;
+    boolean shouldHandleOnBackspace = false;
 
     public ReactAztecText(ThemedReactContext reactContext) {
         super(reactContext);
-        this.setFocusableInTouchMode(true);
-        this.setFocusable(true);
+        this.setOnKeyListener(new ReactAztecText.OnKeyListener() {
+            @Override
+            public boolean onEnterKey() {
+                if (shouldHandleOnEnter) {
+                    onEnter();
+                    return true;
+                }
+                return false;
+            }
+            @Override
+            public boolean onBackSpaceKey() {
+                if (shouldHandleOnBackspace) {
+                    return true;
+                }
+                return false;
+            }
+        });
     }
 
     @Override

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -61,6 +61,7 @@ public class ReactAztecText extends AztecText {
             @Override
             public boolean onBackSpaceKey() {
                 if (shouldHandleOnBackspace) {
+                    onBackspace();
                     return true;
                 }
                 return false;
@@ -220,7 +221,7 @@ public class ReactAztecText extends AztecText {
         this.mIsSettingTextFromJS = mIsSettingTextFromJS;
     }
 
-    public void onEnter() {
+    private void onEnter() {
         disableTextChangedListener();
         String content = toHtml(false);
         int cursorPositionStart = getSelectionStart();
@@ -230,6 +231,20 @@ public class ReactAztecText extends AztecText {
         EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
         eventDispatcher.dispatchEvent(
                 new ReactAztecEnterEvent(getId(), content, cursorPositionStart, cursorPositionEnd)
+        );
+    }
+
+    private void onBackspace() {
+        disableTextChangedListener();
+        String content = toHtml(false);
+        int cursorPositionStart = getSelectionStart();
+        int cursorPositionEnd = getSelectionEnd();
+        enableTextChangedListener();
+        ReactContext reactContext = (ReactContext) getContext();
+        EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+        // TODO: isRTL? Should be passed here?
+        eventDispatcher.dispatchEvent(
+                new ReactAztecBackSpaceEvent(getId(), content, cursorPositionStart, cursorPositionEnd)
         );
     }
 

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -47,16 +47,14 @@ public class ReactAztecText extends AztecText {
             @Override
             public boolean onEnterKey() {
                 if (shouldHandleOnEnter) {
-                    onEnter();
-                    return true;
+                    return onEnter();
                 }
                 return false;
             }
             @Override
-            public boolean onBackSpaceKey() {
+            public boolean onBackspaceKey() {
                 if (shouldHandleOnBackspace) {
-                    onBackspace();
-                    return true;
+                    return onBackspace();
                 }
                 return false;
             }
@@ -215,7 +213,7 @@ public class ReactAztecText extends AztecText {
         this.mIsSettingTextFromJS = mIsSettingTextFromJS;
     }
 
-    private void onEnter() {
+    private boolean onEnter() {
         disableTextChangedListener();
         String content = toHtml(false);
         int cursorPositionStart = getSelectionStart();
@@ -226,13 +224,19 @@ public class ReactAztecText extends AztecText {
         eventDispatcher.dispatchEvent(
                 new ReactAztecEnterEvent(getId(), content, cursorPositionStart, cursorPositionEnd)
         );
+        return true;
     }
 
-    private void onBackspace() {
-        disableTextChangedListener();
-        String content = toHtml(false);
+    private boolean onBackspace() {
         int cursorPositionStart = getSelectionStart();
         int cursorPositionEnd = getSelectionEnd();
+        // Make sure to report backspace at the beginning only, with no selection.
+        if (cursorPositionStart != 0 || cursorPositionEnd != 0) {
+            return false;
+        }
+
+        disableTextChangedListener();
+        String content = toHtml(false);
         enableTextChangedListener();
         ReactContext reactContext = (ReactContext) getContext();
         EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
@@ -240,6 +244,7 @@ public class ReactAztecText extends AztecText {
         eventDispatcher.dispatchEvent(
                 new ReactAztecBackspaceEvent(getId(), content, cursorPositionStart, cursorPositionEnd)
         );
+        return true;
     }
 
     public void applyFormat(String format) {

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -2,8 +2,6 @@ package org.wordpress.mobile.ReactNativeAztec;
 
 import android.support.annotation.Nullable;
 import android.text.Editable;
-import android.text.SpannableStringBuilder;
-import android.text.Spanned;
 import android.text.TextWatcher;
 
 import com.facebook.react.bridge.ReactContext;
@@ -15,15 +13,11 @@ import com.facebook.react.views.textinput.ReactTextChangedEvent;
 import com.facebook.react.views.textinput.ReactTextInputLocalData;
 import com.facebook.react.views.textinput.ScrollWatcher;
 
-import org.wordpress.aztec.AztecParser;
 import org.wordpress.aztec.AztecText;
 import org.wordpress.aztec.AztecTextFormat;
 import org.wordpress.aztec.ITextFormat;
 import org.wordpress.aztec.plugins.IAztecPlugin;
 import org.wordpress.aztec.plugins.IToolbarButton;
-import org.wordpress.aztec.source.Format;
-import org.wordpress.aztec.spans.AztecCursorSpan;
-import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -244,7 +238,7 @@ public class ReactAztecText extends AztecText {
         EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
         // TODO: isRTL? Should be passed here?
         eventDispatcher.dispatchEvent(
-                new ReactAztecBackSpaceEvent(getId(), content, cursorPositionStart, cursorPositionEnd)
+                new ReactAztecBackspaceEvent(getId(), content, cursorPositionStart, cursorPositionEnd)
         );
     }
 

--- a/example/editor.js
+++ b/example/editor.js
@@ -48,6 +48,7 @@ export default class Editor extends Component {
                 onContentSizeChange= { onContentSizeChange }
                 onChange= {(event) => console.log(event.nativeEvent) }
                 onEnter= {(event) => console.log("asta") }
+                onBackspace= {(event) => console.log("Ciao") }
                 onEndEditing= {(event) => console.log(event.nativeEvent) }
                 onActiveFormatsChange = { this.onActiveFormatsChange }
                 color = {'black'}

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -65,6 +65,15 @@ class AztecView extends React.Component {
     onEnter(event);
   }
 
+  _onBackspace = (event) => {
+    if (!this.props.onBackspace) {
+      return;
+    }
+
+    const { onBackspace } = this.props;
+    onBackspace(event);
+  }
+
   _onHTMLContentWithCursor = (event) => {
     if (!this.props.onHTMLContentWithCursor) {
       return;
@@ -85,6 +94,7 @@ class AztecView extends React.Component {
         onContentSizeChange = { this._onContentSizeChange }
         onHTMLContentWithCursor = { this._onHTMLContentWithCursor }
         onEnter = { this._onEnter }
+        onBackspace = { this._onBackspace }
       />
     );
   }

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -15,6 +15,7 @@ class AztecView extends React.Component {
     onChange: PropTypes.func,
     onContentSizeChange: PropTypes.func,
     onEnter: PropTypes.func,
+    onBackspace: PropTypes.func,
     onScroll: PropTypes.func,
     onActiveFormatsChange: PropTypes.func,
     onHTMLContentWithCursor: PropTypes.func,


### PR DESCRIPTION
This PR adds the ability to report to the JS side the backspace pressed event.
The new event is only fired when the backspace happens at the beginning of the Aztec editor.

- `onBackspace` property is added to `AztecView`. If wired is called with the payload about the current html available in Aztec, and the position of the cursor. 
- Updated the demo app.


Note: iOS side is missing in this PR.

AztecAndroid relevant PR here: https://github.com/wordpress-mobile/AztecEditor-Android/pull/752