### PR TITLE
Backspace interception for iOS.

### DIFF
--- a/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/ios/RNTAztecView/RCTAztecViewManager.m
@@ -9,6 +9,7 @@ RCT_EXPORT_MODULE(RCTAztecView)
 
 RCT_REMAP_VIEW_PROPERTY(text, contents, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(onContentSizeChange, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onBackspace, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onEnter, RCTBubblingEventBlock)
 


### PR DESCRIPTION
Adds support to intercept backspaces in iOS.

Should be tested through: https://github.com/wordpress-mobile/gutenberg-mobile/pull/194