### PR TITLE
[Android] Fix wrong editor size after blocks merging

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -93,9 +93,19 @@ public class ReactAztecText extends AztecText {
 
     private void onContentSizeChange() {
         if (mContentSizeWatcher != null) {
-            mContentSizeWatcher.onLayout();
-        }
+            new java.util.Timer().schedule(
+                    new java.util.TimerTask() {
+                        @Override
+                        public void run() {
+                            if (mContentSizeWatcher != null) {
+                                mContentSizeWatcher.onLayout();
 
+                            }
+                        }
+                    },
+                    500
+            );
+        }
         setIntrinsicContentSize();
     }
 


### PR DESCRIPTION
Adds a 500ms delay before calling listeners about changes in editor's dimension.

This fixes a problem on blocks merging, where the wrong size was used after merging two blocks. Giving RN a bit of time to properly update the view, and recalculate its sizes, before calling the listeners.

