### PR TITLE
Temporary workaround for enter key detection logic removed from Aztec

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,10 +77,10 @@ repositories {
 }
 
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:fd5c5ce33eebf9673f50042a77986026e33fc086')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:fd5c5ce33eebf9673f50042a77986026e33fc086')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:fd5c5ce33eebf9673f50042a77986026e33fc086')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:fd5c5ce33eebf9673f50042a77986026e33fc086')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:ed9ab38d47b054ec1623a5ccffb93300a760c6c5')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:ed9ab38d47b054ec1623a5ccffb93300a760c6c5')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:ed9ab38d47b054ec1623a5ccffb93300a760c6c5')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:ed9ab38d47b054ec1623a5ccffb93300a760c6c5')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 


### PR DESCRIPTION
The `Enter.key` detection logic in Aztec was bugged, and then disabled - https://github.com/wordpress-mobile/AztecEditor-Android/issues/760

In this PR i've copied over the previous bugged solution we had in Aztec, that has the repeating characters in the editor problem, and marked it with a fixme statement. We will remove it as soon as we have a working solution in the Aztec main repo.

Test A:
- Start the app
- Go to the end of a para block
- Tap enter
- a new blank block should be added (Do no consider the focus)

Test A:
- Start the app
- Go to the middle of a para block
- Tap enter
- a new block should be added (Do no consider the focus) that has the splitted content

Note: There are problems sometime that a word is lost during the splitting. It's a problem of Aztec and key handling. no need to investigate this further here.

Once this is merged I will open a new PR in GB repo to update the native editor hash.