### PR TITLE
Upgrade to latest Aztec enter.key detection logic

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,10 +77,10 @@ repositories {
 }
 
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:fd5c5ce33eebf9673f50042a77986026e33fc086')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:fd5c5ce33eebf9673f50042a77986026e33fc086')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:fd5c5ce33eebf9673f50042a77986026e33fc086')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:fd5c5ce33eebf9673f50042a77986026e33fc086')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:fbf294b88d17996aff9e3d62a293d2638818dd0a')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:fbf294b88d17996aff9e3d62a293d2638818dd0a')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:fbf294b88d17996aff9e3d62a293d2638818dd0a')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:fbf294b88d17996aff9e3d62a293d2638818dd0a')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -43,7 +43,7 @@ public class ReactAztecText extends AztecText {
 
     public ReactAztecText(ThemedReactContext reactContext) {
         super(reactContext);
-        this.setOnKeyListener(new ReactAztecText.OnKeyListener() {
+        this.setAztecKeyListener(new ReactAztecText.OnAztecKeyListener() {
             @Override
             public boolean onEnterKey() {
                 if (shouldHandleOnEnter) {


### PR DESCRIPTION
This PR upgrade Aztec hash to the latest version available, that uses TextWatchers to intercept Enter.Key pressed event.  https://github.com/wordpress-mobile/AztecEditor-Android/pull/763

Detection of Enter.key pressed event was removed in Aztec few days ago, since there were duplicate content problems with the previous implementation that used `InputFilters`.

Testing steps will be provided in a GB mobile PR soon.

