### PR TITLE
Upgrade react-native and use a more permissive peer dependency requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "peerDependencies": {
     "react": "16.5.0",
-    "react-native": "0.57.1"
+    "react-native": "0.57.5"
   },
   "dependencies": {
     "prop-types": "15.6.0"

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "clean:install": "yarn clean && yarn install"
   },
   "peerDependencies": {
-    "react": "^16.6.1",
-    "react-native": "^0.57.5"
+    "react": "16.6.1",
+    "react-native": "0.57.5"
   },
   "dependencies": {
     "prop-types": "15.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-aztec",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "license": "GPL-2.0",
   "scripts": {
     "install-aztec-ios": "cd ./ios && carthage bootstrap --platform iOS --cache-builds",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "clean:install": "yarn clean && yarn install"
   },
   "peerDependencies": {
-    "react": "16.5.0",
-    "react-native": "0.57.5"
+    "react": "^16.6.1",
+    "react-native": "^0.57.5"
   },
   "dependencies": {
     "prop-types": "15.6.0"


### PR DESCRIPTION
This PR updates `react-native` peer dependency to `^0.57.5` and react to `^16.6.1` ([peer dependency of react-native](https://github.com/facebook/react-native/blob/v0.57.5/package.json#L148))

I don't think it's useful to set fixed version here as it's best to be a bit flexible on what version of react native `gutenberg-mobile` can use with this lib.