### PR TITLE
Improve Focus/Blur handling and show the keyboard accordingly

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -57,6 +57,8 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
     @Override
     protected ReactAztecText createViewInstance(ThemedReactContext reactContext) {
         ReactAztecText aztecText = new ReactAztecText(reactContext);
+        aztecText.setFocusableInTouchMode(true);
+        aztecText.setFocusable(true);
         aztecText.setCalypsoMode(false);
         return aztecText;
     }

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -43,6 +43,12 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
     public static final String REACT_CLASS = "RCTAztecView";
 
+    private static final int COMMAND_NOTIFY_APPLY_FORMAT = 1;
+    private static final int FOCUS_TEXT_INPUT = 2;
+    private static final int BLUR_TEXT_INPUT = 3;
+
+    private static final String TAG = "ReactAztecText";
+
     @Override
     public String getName() {
         return REACT_CLASS;
@@ -51,8 +57,6 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
     @Override
     protected ReactAztecText createViewInstance(ThemedReactContext reactContext) {
         ReactAztecText aztecText = new ReactAztecText(reactContext);
-        aztecText.setFocusableInTouchMode(true);
-        aztecText.setFocusable(true);
         aztecText.setCalypsoMode(false);
         return aztecText;
     }
@@ -242,13 +246,12 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
         view.shouldHandleOnBackspace = onBackspaceHandling;
     }
 
-    private static final int COMMAND_NOTIFY_APPLY_FORMAT = 1;
-    private static final String TAG = "ReactAztecText";
-
     @Override
     public Map<String, Integer> getCommandsMap() {
         return MapBuilder.<String, Integer>builder()
                 .put("applyFormat", COMMAND_NOTIFY_APPLY_FORMAT)
+                .put("focusTextInput", FOCUS_TEXT_INPUT)
+                .put("blurTextInput", BLUR_TEXT_INPUT)
                 .build();
     }
 
@@ -263,6 +266,12 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
                 parent.applyFormat(format);
                 return;
             }
+            case FOCUS_TEXT_INPUT:
+                parent.requestFocusFromJS();
+                break;
+            case BLUR_TEXT_INPUT:
+                parent.clearFocusFromJS();
+                break;
             default:
                 super.receiveCommand(parent, commandType, args);
         }

--- a/example/editor.js
+++ b/example/editor.js
@@ -48,6 +48,8 @@ export default class Editor extends Component {
                 onContentSizeChange= { onContentSizeChange }
                 onChange= {(event) => console.log(event.nativeEvent) }
                 onEnter= {(event) => console.log("asta") }
+                onFocus= {(event) => console.log("onFocus") }
+                onBlur= {(event) => console.log("onBlur") }
                 onBackspace= {(event) => console.log("Ciao") }
                 onEndEditing= {(event) => console.log(event.nativeEvent) }
                 onActiveFormatsChange = { this.onActiveFormatsChange }

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -14,6 +14,8 @@ class AztecView extends React.Component {
     maxImagesWidth: PropTypes.number,
     minImagesWidth: PropTypes.number,
     onChange: PropTypes.func,
+    onFocus: PropTypes.func,
+    onBlur: PropTypes.func,
     onContentSizeChange: PropTypes.func,
     onEnter: PropTypes.func,
     onBackspace: PropTypes.func,
@@ -87,6 +89,24 @@ class AztecView extends React.Component {
     onHTMLContentWithCursor(text, selectionStart, selectionEnd);
   }
 
+  _onFocus = (event) => {
+    if (!this.props.onFocus) {
+      return;
+    }
+
+    const { onFocus } = this.props;
+    onFocus(event);
+  }
+  
+  _onBlur = (event) => {
+    if (!this.props.onBlur) {
+      return;
+    }
+
+    const { onBlur } = this.props;
+    onBlur(event);
+  }
+
   render() {
     const { onActiveFormatsChange, ...otherProps } = this.props    
     return (
@@ -95,6 +115,8 @@ class AztecView extends React.Component {
         onContentSizeChange = { this._onContentSizeChange }
         onHTMLContentWithCursor = { this._onHTMLContentWithCursor }
         onEnter = { this._onEnter }
+        onFocus = { this._onFocus }
+        onBlur = { this._onBlur }
         onBackspace = { this._onBackspace }
       />
     );


### PR DESCRIPTION
This PR does fix the issue where the keyboard is not shown on the screen when you tap on a AztecWrapper field in RN applications. 
It also add 2 other new features (one of those were already present but never exposed to JS) for focus/blur handling in JS.

Details:
- Adds the ability to listen on blur and focus events from the JS side. We can now use `onBlur`, and `onFocus` and attach a JS function to it.

- Does fix an issue where the keyboard is not shown on the screen when the edit field get the focus.

- Adds the ability to set focus or unset it via JS. There are 2 new commands (`focusTextInput ` and `blurTextInput `) that can be invoked JS side to trigger the native side to get or lost the focus.


**Test 1**
- Start the demo app 
- Check that `onBlur` and `onFocus` log lines are present in the log when you jump between fields

**Test 2** (External test with a RN app)
- Use `gb-mobile` master and point react-native-aztec to this hash 357a9a4312d4c842ea1b68f79fb56aff4773f399
- Then start the demo `gb-mobile` app, and tap/jump between AztecWrapper powered blocks
- The keyboard should be visible on the screen
- Dismiss the keyboard
- Tap on a AztecWrapper powered block. The keyboard should be visible now.


I will provide a GB-mobile side PR once this is merged in `master`