### PR TITLE
Propagate selection changes

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -78,6 +78,11 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
                                 "phasedRegistrationNames",
                                 MapBuilder.of("bubbled", "onActiveFormatsChange")))
                 .put(
+                        "topSelectionChange",
+                        MapBuilder.of(
+                                "phasedRegistrationNames",
+                                MapBuilder.of("bubbled", "onSelectionChange")))
+                .put(
                         "topEndEditing",
                         MapBuilder.of(
                                 "phasedRegistrationNames",
@@ -209,7 +214,12 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
     @ReactProp(name = "onActiveFormatsChange", defaultBoolean = false)
     public void setOnActiveFormatsChange(final ReactAztecText view, boolean onActiveFormatsChange) {
-        view.setActiveFormatsChange(onActiveFormatsChange);
+        view.shouldHandleActiveFormatsChange = onActiveFormatsChange;
+    }
+
+    @ReactProp(name = "onSelectionChange", defaultBoolean = false)
+    public void setOnSelectionChange(final ReactAztecText view, boolean onSelectionChange) {
+        view.shouldHandleOnSelectionChange = onSelectionChange;
     }
 
     @ReactProp(name = "onScroll", defaultBoolean = false)

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecSelectionChangeEvent.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecSelectionChangeEvent.java
@@ -1,0 +1,50 @@
+package org.wordpress.mobile.ReactNativeAztec;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted by Aztec native view when selection changes.
+ */
+class ReactAztecSelectionChangeEvent extends Event<ReactAztecSelectionChangeEvent> {
+
+    private static final String EVENT_NAME = "topSelectionChange";
+
+    private String mText;
+    private int mSelectionStart;
+    private int mSelectionEnd;
+
+    public ReactAztecSelectionChangeEvent(int viewId, String text, int selectionStart, int selectionEnd) {
+        super(viewId);
+        mText = text;
+        mSelectionStart = selectionStart;
+        mSelectionEnd = selectionEnd;
+    }
+
+    @Override
+    public String getEventName() {
+        return EVENT_NAME;
+    }
+
+    @Override
+    public boolean canCoalesce() {
+        return false;
+    }
+
+    @Override
+    public void dispatch(RCTEventEmitter rctEventEmitter) {
+        rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+    }
+
+    private WritableMap serializeEventData() {
+        WritableMap eventData = Arguments.createMap();
+        eventData.putInt("target", getViewTag());
+        eventData.putString("text", mText);
+        eventData.putInt("selectionStart", mSelectionStart);
+        eventData.putInt("selectionEnd", mSelectionEnd);
+        return eventData;
+    }
+}

--- a/example/editor.js
+++ b/example/editor.js
@@ -50,6 +50,7 @@ export default class Editor extends Component {
                 onEnter= {(event) => console.log("asta") }
                 onFocus= {(event) => console.log("onFocus") }
                 onBlur= {(event) => console.log("onBlur") }
+                onSelectionChange={ (start, end) => console.log("selectionChange (`start`, `end`)") }
                 onBackspace= {(event) => console.log("Ciao") }
                 onEndEditing= {(event) => console.log(event.nativeEvent) }
                 onActiveFormatsChange = { this.onActiveFormatsChange }

--- a/example/editor.js
+++ b/example/editor.js
@@ -50,7 +50,7 @@ export default class Editor extends Component {
                 onEnter= {(event) => console.log("asta") }
                 onFocus= {(event) => console.log("onFocus") }
                 onBlur= {(event) => console.log("onBlur") }
-                onSelectionChange={ (start, end) => console.log("selectionChange (`start`, `end`)") }
+                onSelectionChange={ (start, end) => console.log(`selectionChange (${start}, ${end})`) }
                 onBackspace= {(event) => console.log("Ciao") }
                 onEndEditing= {(event) => console.log(event.nativeEvent) }
                 onActiveFormatsChange = { this.onActiveFormatsChange }

--- a/ios/RNTAztecView/RCTAztecView.swift
+++ b/ios/RNTAztecView/RCTAztecView.swift
@@ -120,9 +120,14 @@ class RCTAztecView: Aztec.TextView {
     }
     
     func packCaretDataForRN() -> [AnyHashable: Any] {
+        var start = selectedRange.location
+        var end = selectedRange.location + selectedRange.length
+        if selectionAffinity == .backward {
+            (start, end) = (end, start)
+        }
         return ["text": getHTML(),
-                "selectionStart": selectedRange.location,
-                "selectionEnd": selectedRange.location + selectedRange.length,
+                "selectionStart": start,
+                "selectionEnd": end,
         ]
     }
 

--- a/ios/RNTAztecView/RCTAztecView.swift
+++ b/ios/RNTAztecView/RCTAztecView.swift
@@ -7,7 +7,7 @@ class RCTAztecView: Aztec.TextView {
     @objc var onChange: RCTBubblingEventBlock? = nil
     @objc var onEnter: RCTBubblingEventBlock? = nil
     @objc var onContentSizeChange: RCTBubblingEventBlock? = nil
-
+    @objc var onSelectionChange: RCTBubblingEventBlock? = nil
     @objc var onActiveFormatsChange: RCTBubblingEventBlock? = nil
     
     private var previousContentSize: CGSize = .zero
@@ -205,6 +205,14 @@ class RCTAztecView: Aztec.TextView {
         })
         onActiveFormatsChange(["formats": formats])
     }
+
+    func propagateSelectionChanges() {
+        guard let onSelectionChange = onSelectionChange else {
+            return
+        }
+        let caretData = packCaretDataForRN()
+        onSelectionChange(caretData)
+    }
 }
 
 // MARK: UITextView Delegate Methods
@@ -212,6 +220,7 @@ extension RCTAztecView: UITextViewDelegate {
 
     func textViewDidChangeSelection(_ textView: UITextView) {
         propagateFormatChanges()
+        propagateSelectionChanges()
     }
 
     func textViewDidChange(_ textView: UITextView) {

--- a/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/ios/RNTAztecView/RCTAztecViewManager.m
@@ -7,6 +7,7 @@ RCT_EXPORT_VIEW_PROPERTY(onContentSizeChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onBackspace, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onEnter, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onSelectionChange, RCTDirectEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(onActiveFormatsChange, RCTBubblingEventBlock)
 

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -18,6 +18,7 @@ class AztecView extends React.Component {
     onBackspace: PropTypes.func,
     onScroll: PropTypes.func,
     onActiveFormatsChange: PropTypes.func,
+    onSelectionChange: PropTypes.func,
     onHTMLContentWithCursor: PropTypes.func,
     ...ViewPropTypes, // include the default view properties
   }
@@ -86,6 +87,15 @@ class AztecView extends React.Component {
     onHTMLContentWithCursor(text, selectionStart, selectionEnd);
   }
 
+  _onSelectionChange = (event) => {
+    if (!this.props.onSelectionChange) {
+      return;
+    }
+    const { selectionStart, selectionEnd, text } = event.nativeEvent;
+    const { onSelectionChange } = this.props;
+    onSelectionChange(selectionStart, selectionEnd, text);
+  }
+
   render() {
     const { onActiveFormatsChange, ...otherProps } = this.props    
     return (
@@ -93,6 +103,7 @@ class AztecView extends React.Component {
         onActiveFormatsChange={ this._onActiveFormatsChange }
         onContentSizeChange = { this._onContentSizeChange }
         onHTMLContentWithCursor = { this._onHTMLContentWithCursor }
+        onSelectionChange = { this._onSelectionChange }
         onEnter = { this._onEnter }
         onBackspace = { this._onBackspace }
       />


### PR DESCRIPTION
This PR adds a new `onSelectionChange` prop to let React Native know when the selection has changed.

To test:

- Run and debug the example app
- As you move the cursor around and change the selection, there should be an entry in the log file with the selection range