### PR TITLE
Use TextInputState for focus and blur

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -43,9 +43,9 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
     public static final String REACT_CLASS = "RCTAztecView";
 
-    private static final int COMMAND_NOTIFY_APPLY_FORMAT = 1;
-    private static final int FOCUS_TEXT_INPUT = 2;
-    private static final int BLUR_TEXT_INPUT = 3;
+    private static final int FOCUS_TEXT_INPUT = 1;
+    private static final int BLUR_TEXT_INPUT = 2;
+    private static final int COMMAND_NOTIFY_APPLY_FORMAT = 3;
 
     private static final String TAG = "ReactAztecText";
 
@@ -270,7 +270,6 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
     @Override
     public void receiveCommand(final ReactAztecText parent, int commandType, @Nullable ReadableArray args) {
         Assertions.assertNotNull(parent);
-        Assertions.assertNotNull(args);
         switch (commandType) {
             case COMMAND_NOTIFY_APPLY_FORMAT: {
                 final String format = args.getString(0);

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactNative, {requireNativeComponent, ViewPropTypes, UIManager, ColorPropType} from 'react-native';
+import TextInputState from 'react-native/lib/TextInputState';
 
 class AztecView extends React.Component {
   
@@ -91,6 +92,8 @@ class AztecView extends React.Component {
   }
 
   _onFocus = (event) => {
+    TextInputState.focusTextInput(ReactNative.findNodeHandle(this));
+
     if (!this.props.onFocus) {
       return;
     }
@@ -100,6 +103,8 @@ class AztecView extends React.Component {
   }
   
   _onBlur = (event) => {
+    TextInputState.blurTextInput(ReactNative.findNodeHandle(this));
+
     if (!this.props.onBlur) {
       return;
     }


### PR DESCRIPTION
This PR makes use of `TextInputState.focusTextInput` and `TextInputState.blurTextInput` methods to signal our own Aztec wrapper to focus/hide keyboard

For this, the PR does a trick of re-using the same values [as in ReactNative](https://github.com/facebook/react-native/blob/95174d4ea8d050305885f3cc2a4c99e2b83fc961/Libraries/Components/TextInput/TextInputState.js) for
```
UIManager.getViewManagerConfig('AndroidTextInput').Commands
          .blurTextInput,
```
and
```
UIManager.getViewManagerConfig('AndroidTextInput').Commands
          .focusTextInput,
```

defined in Java (android) [here](https://github.com/facebook/react-native/blob/c5186aeb461a6eafa582b0acba1b3cebfb83550b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java#L167
):
```
@Override
  public @Nullable Map<String, Integer> getCommandsMap() {
    return MapBuilder.of("focusTextInput", FOCUS_TEXT_INPUT, "blurTextInput", BLUR_TEXT_INPUT);
  }
```
whereas: 
```
private static final int FOCUS_TEXT_INPUT = 1;
  private static final int BLUR_TEXT_INPUT = 2;
```

I was planning to add tests to make sure we track there are no changes in these values in the feature and make the test not pass if/whenever such a thing happens, so we can keep using TextInputState to handle the focus on Aztec while being "coordinated" with the rest of ReactNative `TextInput` instances when multiple of them exists. These tests will come on another PR, as we need to move on with this to fix other issues.

Thanks @koke for putting this together!

