### PR TITLE
Ability to build a binary via jitpack

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,14 +69,19 @@ android {
     }
 }
 
-
 repositories {
     jcenter()
     google()
-    maven {
-        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        url "https://unpkg.com/react-native@0.57.1/android"
+
+    if (project == rootProject) {
+        // if we are the root project, use a remote RN maven repo so jitpack can build this lib without local RN setup
+        println 'Will use the unpkg.com provided RN'
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url "https://unpkg.com/react-native@0.57.1/android"
+        }
     }
+
     maven { url "https://jitpack.io" }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,6 +73,10 @@ android {
 repositories {
     jcenter()
     google()
+    maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        url "https://unpkg.com/react-native@0.57.1/android"
+    }
     maven { url "https://jitpack.io" }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,9 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+// import the `readReactNativeVersion()` function
+apply from: 'https://gist.githubusercontent.com/hypest/742448b9588b3a0aa580a5e80ae95bdf/raw/8eb62d40ee7a5104d2fcaeff21ce6f29bd93b054/readReactNativeVersion.gradle'
+
 // The sample build uses multiple directories to
 // keep boilerplate and common code separate from
 // the main sample code.
@@ -75,10 +78,12 @@ repositories {
 
     if (project == rootProject) {
         // if we are the root project, use a remote RN maven repo so jitpack can build this lib without local RN setup
-        println 'Will use the unpkg.com provided RN'
+        def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
+        def unpkgUrl = "https://unpkg.com/react-native@${rnVersion}/android"
+        println "Will use the unpkg.com exposed RN maven repo at ${unpkgUrl}"
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url "https://unpkg.com/react-native@0.57.1/android"
+            url unpkgUrl
         }
     }
 


### PR DESCRIPTION
This PR is part of the integration with wpandroid effort (https://github.com/wordpress-mobile/gutenberg-mobile/issues/163).

It enables building the android library of `react-native-aztec` as a standalone lib, via jitpack, just by referencing the repo and commit hash. It does this by adding a maven repo for the ReactNative vendor binaries. The maven repo is provided by the https://unpkg.com service which exposes npm packages via the web.

Changes in this PR:
1. Adds a maven repo with the RN binaries
2. Picks up the RN version used in the main `package.json` to point to the corresponding maven repo on unpkg.com
3. Introduces the `readReactNativeVersion()` gradle helper function, currently living as a GitHub gist [here](https://gist.github.com/hypest/742448b9588b3a0aa580a5e80ae95bdf/), for parsing the package.json and reading the react-native version set there.

## To test

### Test A

0. Make sure there is no `node_modules` folder, either in the root or in the `example` folder
1. `cd` into the `android` subfolder and build by issuing `./gradlew assemble`
2. The build should succeed
3. Scroll up and notice the `Will use the unpkg.com exposed RN maven repo at https://unpkg.com/react-native@0.57.5/android` printout which shows that the remote maven repo was in effect.

### Test B

1. Compile and run the android demo app of the `react-native-aztec` project, doing any necessary `yarn install` calls for that
2. While building the android app, notice that *there is no* `Will use the unpkg.com exposed RN maven repo at https://unpkg.com/react-native@0.57.5/android` printout.
3. The app should run fine