### PR TITLE
Use focusTextInput and blurTextInput  codes from RN's ReactTexInputManager

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -46,7 +46,7 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
     private static final int FOCUS_TEXT_INPUT = 1;
     private static final int BLUR_TEXT_INPUT = 2;
-    private static final int COMMAND_NOTIFY_APPLY_FORMAT = 3;
+    private static final int COMMAND_NOTIFY_APPLY_FORMAT = 100;
 
     // we define the same codes in ReactAztecText as they have for ReactNative's TextInput, so
     // it's easier to handle focus between Aztec and TextInput instances on the same screen.


### PR DESCRIPTION
Since #79, `ReactAztecText` piggybacks on React Native's `TextInputState` class to handle focus and blur requests in the same manner for both `ReactAztecText` and `TextInput`, by means of re-using the same command codes for `focus`  and `blur` respectively, thus giving the actions the same meaning regardless of the context (`ViewManager` name) in which the command have been issued in the first place. 

- In order to prevent future arbitrary changes in RN code that will break Aztec's focus, we're now initializing the values for command codes in this PR with the same values existing in RN's `ReactTextInputManager`, thus ensuring if they'll ever change this should be a transparent change for us to make (173b7b0).

- Also in 0fb1713 we added a bigger value to those commands that are specific to `ReactAztecText`, namely `COMMAND_NOTIFY_APPLY_FORMAT` for the time being, in case other commands with the same meaning as existing ones in `TextInput` need be added to ReactAztecText in the future (which would not be the only needed change if such a case happens, but at least we care to not allow overlapping in the first place).

#### Test case 1:
1. change the value of the constants FOCUS_TEXT_INPUT and BLUR_TEXT_INPUT to something else, like 67 and 43 (random numbers different to 1 and 2 respectively)
2. observe the focus still gets handled correctly (because the values are gotten from `ReactTextInputManager` class).
3. place some `Log.d(TAG, message)` calls in `createReactTextInputManager()` to verify the values are being retrieved from such class correctly.

```
        Map<String, Integer> map = reactTextInputManager.getCommandsMap();
        mFocusTextInputCommandCode = map.get("focusTextInput");
        mBlurTextInputCommandCode = map.get("blurTextInput");
        Log.d("TAG", "retrieved focus code is: " + mFocusTextInputCommandCode);
        Log.d("TAG", "retrieved blur code is: " + mBlurTextInputCommandCode);
```

You should see the following output in logcat:

```
[...]
11-27 18:39:09.295 1808-1837/? D/ReactNative: ReactInstanceManager.createReactContext()
11-27 18:39:09.298 1808-1837/? D/TAG: retrieved focus code is: 1
    retrieved blur code is: 2
[...]
```


#### Test case 2: (use with Gutenberg)
1. update the `react-native-aztec` hash submodule to point to commit 0fb1713 (or this branch `fix/focus-arbitrary-codes`)
2. compile & run the Android Gutenberg demo app with `yarn android`
3. observe you can focus on a `RichText`-based  block and change the cursor position by tapping on different places within the same block without problems.
