### PR TITLE
Use NotoSerif by default or at least a bigger font

### DIFF
--- a/ios/RNTAztecView/RCTAztecViewManager.swift
+++ b/ios/RNTAztecView/RCTAztecViewManager.swift
@@ -21,7 +21,7 @@ public class RCTAztecViewManager: RCTViewManager {
     @objc
     public override func view() -> UIView {
         let view = RCTAztecView(
-            defaultFont: .systemFont(ofSize: 12),
+            defaultFont: defaultFont,
             defaultParagraphStyle: .default,
             defaultMissingImage: UIImage())
 
@@ -43,5 +43,22 @@ public class RCTAztecViewManager: RCTViewManager {
             }
             block(aztecView)
         }
+    }
+
+    private var defaultFont: UIFont {
+        if let font = UIFont(name: "NotoSerif", size: 16) {
+            return font
+        }
+
+        let defaultFont = UIFont.systemFont(ofSize: 16)
+        guard let url = Bundle.main.url(forResource: "NotoSerif-Regular", withExtension: "ttf") else {
+            return defaultFont
+        }
+        CTFontManagerRegisterFontsForURL(url as CFURL, CTFontManagerScope.process, nil)
+        if let font = UIFont(name: "NotoSerif", size: 16) {
+            return font
+        }
+
+        return defaultFont
     }
 }


### PR DESCRIPTION
The existing default font was too tiny, I updated it to 16 points to match Aztec.
Also, if the NotoSerif font is available it will use that. I'm not super happy with the implementation, but making it configurable seemed like a lot of effort for now.

To test:

From WordPress-iOS, edit the `Podfile` and point the `RNTAztecView` pod to this branch:
```
pod 'RNTAztecView', :git => 'https://github.com/wordpress-mobile/react-native-aztec.git', :branch => 'feature/noto-fonts'
```

Run `bundle exec pod update RNTAztecView`

Run the app, create or edit a post with Gutenberg and verify that the paragraph/heading blocks are using NotoSerif

If you run the gutenberg-mobile example app, it should show paragraphs with the system fonts but at 16 points.