### PR TITLE
Replicate how focus works on TextInput

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -106,10 +106,6 @@ public class ReactAztecText extends AztecText {
 
     @Override
     public void clearFocus() {
-        // Don't clear focus if we don't have it, or it'll clear the focus for another field
-        if (!isFocused()) {
-            return;
-        }
         setFocusableInTouchMode(false);
         super.clearFocus();
         hideSoftKeyboard();

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactNative, {requireNativeComponent, ViewPropTypes, UIManager, ColorPropType} from 'react-native';
+import ReactNative, {requireNativeComponent, ViewPropTypes, UIManager, ColorPropType, TouchableWithoutFeedback} from 'react-native';
 import TextInputState from 'react-native/lib/TextInputState';
 
 class AztecView extends React.Component {
@@ -92,8 +92,6 @@ class AztecView extends React.Component {
   }
 
   _onFocus = (event) => {
-    TextInputState.focusTextInput(ReactNative.findNodeHandle(this));
-
     if (!this.props.onFocus) {
       return;
     }
@@ -122,19 +120,25 @@ class AztecView extends React.Component {
     onSelectionChange(selectionStart, selectionEnd, text);
   }
 
+  _onPress = () => {
+    TextInputState.focusTextInput(ReactNative.findNodeHandle(this));
+  }
+
   render() {
     const { onActiveFormatsChange, ...otherProps } = this.props    
     return (
-      <RCTAztecView {...otherProps} 
-        onActiveFormatsChange={ this._onActiveFormatsChange }
-        onContentSizeChange = { this._onContentSizeChange }
-        onHTMLContentWithCursor = { this._onHTMLContentWithCursor }
-        onSelectionChange = { this._onSelectionChange }
-        onEnter = { this._onEnter }
-        onFocus = { this._onFocus }
-        onBlur = { this._onBlur }
-        onBackspace = { this._onBackspace }
-      />
+      <TouchableWithoutFeedback onPress={ this._onPress }>
+        <RCTAztecView {...otherProps}
+          onActiveFormatsChange={ this._onActiveFormatsChange }
+          onContentSizeChange = { this._onContentSizeChange }
+          onHTMLContentWithCursor = { this._onHTMLContentWithCursor }
+          onSelectionChange = { this._onSelectionChange }
+          onEnter = { this._onEnter }
+          onFocus = { this._onFocus }
+          onBlur = { this._onBlur }
+          onBackspace = { this._onBackspace }
+        />
+      </TouchableWithoutFeedback>
     );
   }
 }


### PR DESCRIPTION
Another take on https://github.com/wordpress-mobile/gutenberg-mobile/issues/291, reverts the previous PR #83.

Instead of asking to focus from onFocus, this wraps the AztecView inside a TouchableWithoutFeedback, and asks to focus when pressed. This seems to work because the focus event gets now captured by TextInputState before Aztec blurs the previous field.

To test, check out the other PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/296