### PR TITLE
Expose focus method

### DIFF
--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -120,8 +120,12 @@ class AztecView extends React.Component {
     onSelectionChange(selectionStart, selectionEnd, text);
   }
 
-  _onPress = () => {
+  focus = () => {
     TextInputState.focusTextInput(ReactNative.findNodeHandle(this));
+  }
+
+  _onPress = () => {
+    this.focus();
   }
 
   render() {


### PR DESCRIPTION
This will allow us to explicitly set the focus from RichText

To test see https://github.com/wordpress-mobile/gutenberg-mobile/pull/298