### PR TITLE
Fix `onFocus` called too many times 

### DIFF
--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -139,7 +139,10 @@ class AztecView extends React.Component {
           onHTMLContentWithCursor = { this._onHTMLContentWithCursor }
           onSelectionChange = { this._onSelectionChange }
           onEnter = { this._onEnter }
-          onFocus = { () => {} } // Do nothing here, the onPress takes care of everything
+          // IMPORTANT: the onFocus events are thrown away as these are handled by onPress() in the upper level.
+          // It's necessary to do this otherwise onFocus may be set by `{...otherProps}` and thus the onPress + onFocus
+          // combination generate an infinite loop as described in https://github.com/wordpress-mobile/gutenberg-mobile/issues/302
+          onFocus = { () => {} } 
           onBlur = { this._onBlur }
           onBackspace = { this._onBackspace }
         />

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -125,7 +125,8 @@ class AztecView extends React.Component {
   }
 
   _onPress = () => {
-    this.focus();
+    this.focus(); // Call to move the focus in RN way (TextInputState)
+    this._onFocus(); // Check if there are listeners set on the focus event
   }
 
   render() {
@@ -138,7 +139,7 @@ class AztecView extends React.Component {
           onHTMLContentWithCursor = { this._onHTMLContentWithCursor }
           onSelectionChange = { this._onSelectionChange }
           onEnter = { this._onEnter }
-          onFocus = { this._onFocus }
+          onFocus = { () => {} } // Do nothing here, the onPress takes care of everything
           onBlur = { this._onBlur }
           onBackspace = { this._onBackspace }
         />


### PR DESCRIPTION
This PR fixes an issue where multiple instances of AztecWrapper in the same screen can lead to a focus loop. See [Focus Loop when deleting content and blocks](https://github.com/wordpress-mobile/gutenberg-mobile/issues/302).

Removing the `onFocus` bind, and relying only `onPress` fixes the problem.

Testing steps provided in the other PR here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/314.