### PR TITLE
Adding set/remove link methods.

### DIFF
--- a/ios/RNTAztecView/RCTAztecView.swift
+++ b/ios/RNTAztecView/RCTAztecView.swift
@@ -182,6 +182,26 @@ class RCTAztecView: Aztec.TextView {
         default: print("Format not recognized")
         }
     }
+
+    @objc
+    func setLink(with url: String, and title: String?) {
+        guard let url = URL(string: url) else {
+            return
+        }
+        if let title = title {
+            setLink(url, title: title, inRange: selectedRange)
+        } else {
+            setLink(url, inRange: selectedRange)
+        }
+    }
+
+    @objc
+    func removeLink() {
+        guard let expandedRange = linkFullRange(forRange: selectedRange) else {
+            return
+        }
+        removeLink(inRange: expandedRange)
+    }
     
     // MARK: - Event Propagation
     

--- a/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/ios/RNTAztecView/RCTAztecViewManager.m
@@ -12,6 +12,7 @@ RCT_EXPORT_VIEW_PROPERTY(onBlur, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onSelectionChange, RCTDirectEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(onActiveFormatsChange, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onActiveFormatAttributesChange, RCTBubblingEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(placeholderTextColor, UIColor)

--- a/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/ios/RNTAztecView/RCTAztecViewManager.m
@@ -17,5 +17,8 @@ RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(placeholderTextColor, UIColor)
 
 RCT_EXTERN_METHOD(applyFormat:(nonnull NSNumber *)node format:(NSString *)format)
+RCT_EXTERN_METHOD(setLinkToSelected:(nonnull NSNumber *)node url:(NSString *)url)
+RCT_EXTERN_METHOD(setLink:(nonnull NSNumber *)node url:(nonnull NSString *)url title:(nullable NSString *)title)
+RCT_EXTERN_METHOD(removeLink:(nonnull NSNumber *)node)
 
 @end

--- a/ios/RNTAztecView/RCTAztecViewManager.swift
+++ b/ios/RNTAztecView/RCTAztecViewManager.swift
@@ -19,6 +19,20 @@ public class RCTAztecViewManager: RCTViewManager {
     }
 
     @objc
+    func removeLink(_ node: NSNumber) {
+        executeBlock({ (aztecView) in
+            aztecView.removeLink()
+        }, onNode: node)
+    }
+
+    @objc
+    func setLink(_ node: NSNumber, url: String, title: String?) {
+        executeBlock({ (aztecView) in
+            aztecView.setLink(with: url, and: title)
+        }, onNode: node)
+    }
+
+    @objc
     public override func view() -> UIView {
         let view = RCTAztecView(
             defaultFont: defaultFont,

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -3,6 +3,8 @@ import React from 'react';
 import ReactNative, {requireNativeComponent, ViewPropTypes, UIManager, ColorPropType, TouchableWithoutFeedback} from 'react-native';
 import TextInputState from 'react-native/lib/TextInputState';
 
+const AztecManager = UIManager.RCTAztecView;
+
 class AztecView extends React.Component {
   
   static propTypes = {
@@ -27,20 +29,29 @@ class AztecView extends React.Component {
     ...ViewPropTypes, // include the default view properties
   }
 
-  applyFormat(format) {   
+  dispatch(command, params) {
+    params = params || [];
     UIManager.dispatchViewManagerCommand(
                                           ReactNative.findNodeHandle(this),
-                                          UIManager.RCTAztecView.Commands.applyFormat,
-                                          [format],
-                                        );    
+                                          command,
+                                          params,
+    );
+  }
+
+  applyFormat(format) {
+    this.dispatch(AztecManager.Commands.applyFormat, [format])
+  }
+
+  removeLink() {
+    this.dispatch(AztecManager.Commands.removeLink)
+  }
+
+  setLink(url, title) {
+    this.dispatch(AztecManager.Commands.setLink, [url, title])
   }
 
   requestHTMLWithCursor() {
-    UIManager.dispatchViewManagerCommand(
-                                          ReactNative.findNodeHandle(this),
-                                          UIManager.RCTAztecView.Commands.returnHTMLWithCursor,
-                                          [],
-                                        );    
+    this.dispatch(AztecManager.Commands.returnHTMLWithCursor)
   }
 
   _onActiveFormatsChange = (event) => {

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -24,6 +24,7 @@ class AztecView extends React.Component {
     onBackspace: PropTypes.func,
     onScroll: PropTypes.func,
     onActiveFormatsChange: PropTypes.func,
+    onActiveFormatAttributesChange: PropTypes.func,
     onSelectionChange: PropTypes.func,
     onHTMLContentWithCursor: PropTypes.func,
     ...ViewPropTypes, // include the default view properties
@@ -61,6 +62,15 @@ class AztecView extends React.Component {
     const formats = event.nativeEvent.formats;
     const { onActiveFormatsChange } = this.props;
     onActiveFormatsChange(formats);
+  }
+
+  _onActiveFormatAttributesChange = (event) => {
+    if (!this.props.onActiveFormatAttributesChange) {
+      return;
+    }
+    const attributes = event.nativeEvent.attributes;
+    const { onActiveFormatAttributesChange } = this.props;
+    onActiveFormatAttributesChange(attributes);
   }
 
   _onContentSizeChange = (event) => {
@@ -145,6 +155,7 @@ class AztecView extends React.Component {
       <TouchableWithoutFeedback onPress={ this._onPress }>
         <RCTAztecView {...otherProps}
           onActiveFormatsChange={ this._onActiveFormatsChange }
+          onActiveFormatAttributesChange={ this._onActiveFormatAttributesChange }
           onContentSizeChange = { this._onContentSizeChange }
           onHTMLContentWithCursor = { this._onHTMLContentWithCursor }
           onSelectionChange = { this._onSelectionChange }


### PR DESCRIPTION
This PR is one step to implement Links managing in Gutenberg mobile.

### The current implementation on `RCTAztecView` is:

```javascript
//To set a link for the selected text:
setLink("link-to-add.com")

//To set a link without selecting text, with the given title (or text):
setLink("link-to-add.com", "title")

//To remove a link currently under the cursor (selected or not selected):
removeLink()
```

To give back the information of the current url for the link was quite challenging. My initial intention was to implement a function like `getLinkAttributes(callback)` that we could call when the information is needed. But I didn't find a way to make it work (Native UI Components seems to be quite different to plane Native Module Components).

To solve this problem and to be able to give back that information to the JS side, I decided to use the same strategy used on `onActiveFormatsChange`, but giving more information.

I added a `onActiveFormatAttributesChange`, with a current implementation with just links.
If you select or navigate the cursor to anywhere with a link format, `onActiveFormatAttributesChange` will be called with this info:
```javascript
link: {
    isActive: true
    url: "wp.com", 
}
```
For any other time, it will be called with:
```javascript
link: {
    isActive: false 
}
```

This could be used for other attributes and potentially replace `onActiveFormatsChange`.

@Tug let me know what do you think about it. We can still try to find another way, but I didn't find anyway to use callbacks (or promises) to ask and get info back from native code.

In the branch `gutenberg/rnmobile/test-links` you can find a testing code, and see how it looks:
https://github.com/WordPress/gutenberg/compare/mobile...rnmobile/test-links

![links](https://user-images.githubusercontent.com/9772967/49474426-6b0e1a00-f7f3-11e8-89bd-92b0398a7f68.gif)
