### PR TITLE
Remove unneeded Aztec toolbar configuration

### DIFF
--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
-    <style name="AztecToolbarStyle">
-        <item name="advanced">false</item>
-        <item name="mediaToolbarAvailable">false</item>
-    </style>
-
-</resources>


### PR DESCRIPTION
Fixes #88 

We are not using the Android Aztec Toolbar in gutenberg-mobile and apparently the existence of this file is a sleeper bug so, removing it.

Note: the example app has its own copy of the AztecToolbarStyle configuration in https://github.com/wordpress-mobile/react-native-aztec/blob/master/example/android/app/src/main/res/values/styles.xml. We don't need to remove that one since it's only used in the example app, not the library.

To test:

Run the example app and notice that everything renders fine and editing works as normal.