### PR TITLE
Prioritize jitpack over unpkg

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -81,11 +81,11 @@ repositories {
     if (project == rootProject) {
         // if we are the root project, use a remote RN maven repo so jitpack can build this lib without local RN setup
         def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
-        def unpkgUrl = "https://unpkg.com/react-native@${rnVersion}/android"
-        println "Will use the unpkg.com exposed RN maven repo at ${unpkgUrl}"
+        def npmCdnUrl = "https://cdn.jsdelivr.net/npm/react-native@${rnVersion}/android"
+        println "Will use the jsdelivr.net exposed RN maven repo at ${npmCdnUrl}"
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url unpkgUrl
+            url npmCdnUrl
         }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,6 +76,8 @@ repositories {
     jcenter()
     google()
 
+    maven { url "https://jitpack.io" }
+
     if (project == rootProject) {
         // if we are the root project, use a remote RN maven repo so jitpack can build this lib without local RN setup
         def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
@@ -86,8 +88,6 @@ repositories {
             url unpkgUrl
         }
     }
-
-    maven { url "https://jitpack.io" }
 }
 
 dependencies {


### PR DESCRIPTION
Due to some recent 503 errors returned by unpkg.com (See this issue https://github.com/unpkg/unpkg.com/issues/153) the PR:

* Prioritizes the JitPack maven repo to be earlier than the NPM CDN's, to avoid pinging the CDN for artifacts that we know are not there (but are on JitPack)
* Switches over to using jsdelivr.net as the NPM CDN. We might start using both at some point but for now let's switch to jsdelivr.net.

To test:
1. Change into the `android` subfolder and execute `./gradlew assemble`
2. It should succeed and in the process print out `Will use the jsdelivr.net exposed RN maven repo at https://cdn.jsdelivr.net/npm/react-native@0.57.5/android`