### PR TITLE
Pass the original RN event to the `onPress` callback

### DIFF
--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -124,9 +124,9 @@ class AztecView extends React.Component {
     TextInputState.focusTextInput(ReactNative.findNodeHandle(this));
   }
 
-  _onPress = () => {
-    this.focus(); // Call to move the focus in RN way (TextInputState)
-    this._onFocus(); // Check if there are listeners set on the focus event
+  _onPress = (event) => {
+    this.focus(event); // Call to move the focus in RN way (TextInputState)
+    this._onFocus(event); // Check if there are listeners set on the focus event
   }
 
   render() {


### PR DESCRIPTION
This PR makes sure that the original `onPress` React Native event is passed to the relevant code that is executed on press.

This is required in GB-mobile to fix an issue with the keyboard that is not being dismissed properly, and in general we should not hide events to the callbacks if not strictly required.

A GB  side PR will soon arrive.