### PR TITLE
Add `blur` method to AztecView

### DIFF
--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -120,6 +120,10 @@ class AztecView extends React.Component {
     onSelectionChange(selectionStart, selectionEnd, text);
   }
 
+  blur = () => {
+    TextInputState.blurTextInput(ReactNative.findNodeHandle(this));
+  }
+
   focus = () => {
     TextInputState.focusTextInput(ReactNative.findNodeHandle(this));
   }


### PR DESCRIPTION
This PR adds the blur method to `AztecView` by using TextInputState.


This PR will be used in GB mobile to be able to dismiss the keyboard when the focus moves from a "TextInput" component to another kind of component that does not required the keyboard.

GB mobile link will soon be available _link_still_missing_