### PR TITLE
Move `topSelectionChange` to direct event, and be in par with iOS side

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -25,8 +25,8 @@ import com.facebook.react.views.text.DefaultStyleValuesUtil;
 import com.facebook.react.views.textinput.ReactContentSizeChangedEvent;
 import com.facebook.react.views.textinput.ReactTextChangedEvent;
 import com.facebook.react.views.textinput.ReactTextInputEvent;
-import com.facebook.react.views.textinput.ScrollWatcher;
 import com.facebook.react.views.textinput.ReactTextInputManager;
+import com.facebook.react.views.textinput.ScrollWatcher;
 
 import org.wordpress.aztec.glideloader.GlideImageLoader;
 import org.wordpress.aztec.glideloader.GlideVideoThumbnailLoader;
@@ -105,11 +105,6 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
                                 "phasedRegistrationNames",
                                 MapBuilder.of("bubbled", "onActiveFormatsChange")))
                 .put(
-                        "topSelectionChange",
-                        MapBuilder.of(
-                                "phasedRegistrationNames",
-                                MapBuilder.of("bubbled", "onSelectionChange")))
-                .put(
                         "topEndEditing",
                         MapBuilder.of(
                                 "phasedRegistrationNames",
@@ -145,6 +140,15 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
                                 "phasedRegistrationNames",
                                 MapBuilder.of("bubbled", "onKeyPress", "captured", "onKeyPressCapture")))*/
                 .build();
+    }
+
+    @Nullable
+    @Override
+    public Map getExportedCustomDirectEventTypeConstants() {
+        return MapBuilder.of(
+                "topSelectionChange",
+                MapBuilder.of("registrationName", "onSelectionChange")
+                );
     }
 
     @ReactProp(name = "text")


### PR DESCRIPTION
This PR fixes an issue where the `topSelectionChange` was declared  as "bubbled" event in Android but it's conflicting with the iOS where it was declared direct.


See https://github.com/wordpress-mobile/react-native-aztec/commit/53b23e10f0365f2503f0c2a22a006375d243e4a5#diff-53629a685cde108964f81f3aad89a6e0R10

PR that introduced the issue: https://github.com/wordpress-mobile/react-native-aztec/pull/76


