### PR TITLE
Blocks no longer merge when pressing backspace with a non-zero-length selection.

### DIFF
--- a/ios/RNTAztecView/RCTAztecView.swift
+++ b/ios/RNTAztecView/RCTAztecView.swift
@@ -96,7 +96,7 @@ class RCTAztecView: Aztec.TextView {
     }
     
     private func interceptBackspace() -> Bool {
-        guard selectedRange.location == 0,
+        guard selectedRange.location == 0 && selectedRange.length == 0,
             let onBackspace = onBackspace else {
                 return false
         }


### PR DESCRIPTION
### Description:

Title has it.

Fixes #325

### Related PRs:

The `gutenberg-mobile` PR that corresponds to this one can be found [here](https://github.com/wordpress-mobile/gutenberg-mobile/pull/352).

### Testing:

Test this PR through the `gutenberg-mobile` related PR.