### PR TITLE
[iOS] Adds support for forward merging of blocks when pressing DELETE.

### DIFF
--- a/ios/RNTAztecView/RCTAztecView.swift
+++ b/ios/RNTAztecView/RCTAztecView.swift
@@ -96,7 +96,7 @@ class RCTAztecView: Aztec.TextView {
     }
     
     private func interceptBackspace() -> Bool {
-        guard selectedRange.location == 0,
+        guard selectedRange.location == 0 && selectedRange.length == 0,
             let onBackspace = onBackspace else {
                 return false
         }

--- a/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/ios/RNTAztecView/RCTAztecViewManager.m
@@ -5,6 +5,7 @@
 RCT_REMAP_VIEW_PROPERTY(text, contents, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(onContentSizeChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onBackspace, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onDelete, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onEnter, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFocus, RCTBubblingEventBlock)

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -20,6 +20,7 @@ class AztecView extends React.Component {
     onContentSizeChange: PropTypes.func,
     onEnter: PropTypes.func,
     onBackspace: PropTypes.func,
+    onDelete: PropTypes.func,
     onScroll: PropTypes.func,
     onActiveFormatsChange: PropTypes.func,
     onSelectionChange: PropTypes.func,
@@ -77,6 +78,15 @@ class AztecView extends React.Component {
 
     const { onBackspace } = this.props;
     onBackspace(event);
+  }
+
+  _onDelete = (event) => {
+    if (!this.props.onDelete) {
+      return;
+    }
+
+    const { onDelete } = this.props;
+    onDelete(event);
   }
 
   _onHTMLContentWithCursor = (event) => {
@@ -149,6 +159,7 @@ class AztecView extends React.Component {
           onFocus = { () => {} } 
           onBlur = { this._onBlur }
           onBackspace = { this._onBackspace }
+          onDelete = { this._onDelete }
         />
       </TouchableWithoutFeedback>
     );


### PR DESCRIPTION
### Description:

Pressing FN + Delete now properly merges blocks forward when appropriate.

### Related PRs:

`gutenberg`: https://github.com/WordPress/gutenberg/pull/12809
`gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/353

### Details:

TBD