### PR TITLE
[iOS]: Fix issue where heading blocks are not behaving properly.

### DIFF
--- a/ios/Cartfile
+++ b/ios/Cartfile
@@ -1,2 +1,2 @@
-github "wordpress-mobile/AztecEditor-iOS" "81c00508d173340d6e2c565f11a7db54596ce699"
+github "wordpress-mobile/AztecEditor-iOS" "f946678f319302ac6a8eb2e830a285a1ce9602db"
 

--- a/ios/Cartfile
+++ b/ios/Cartfile
@@ -1,2 +1,2 @@
-github "wordpress-mobile/AztecEditor-iOS" "05f59f5038561c066a39dd9d81ea063d8b7e5f61"
+github "wordpress-mobile/AztecEditor-iOS" "81c00508d173340d6e2c565f11a7db54596ce699"
 

--- a/ios/Cartfile
+++ b/ios/Cartfile
@@ -1,2 +1,2 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.3"
+github "wordpress-mobile/AztecEditor-iOS" "05f59f5038561c066a39dd9d81ea063d8b7e5f61"
 

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "1.3"
+github "wordpress-mobile/AztecEditor-iOS" "05f59f5038561c066a39dd9d81ea063d8b7e5f61"

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "81c00508d173340d6e2c565f11a7db54596ce699"
+github "wordpress-mobile/AztecEditor-iOS" "f946678f319302ac6a8eb2e830a285a1ce9602db"

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "05f59f5038561c066a39dd9d81ea063d8b7e5f61"
+github "wordpress-mobile/AztecEditor-iOS" "81c00508d173340d6e2c565f11a7db54596ce699"

--- a/ios/RNTAztecView.xcodeproj/project.pbxproj
+++ b/ios/RNTAztecView.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7ECFA93C21C39B5000FC131B /* HeadingBlockFormatHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECFA93B21C39B5000FC131B /* HeadingBlockFormatHandler.swift */; };
+		7ECFA94021C39BA000FC131B /* BlockFormatHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECFA93F21C39BA000FC131B /* BlockFormatHandler.swift */; };
+		7ECFA94221C39BBB00FC131B /* BlockModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECFA94121C39BBB00FC131B /* BlockModel.swift */; };
 		F121467D20ED2F81003DD17B /* RCTAztecViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F121467C20ED2F81003DD17B /* RCTAztecViewManager.m */; };
 		F13BF4A020ECF5450047D3F9 /* RCTAztecViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13BF49F20ECF5450047D3F9 /* RCTAztecViewManager.swift */; };
 		F166A38020EE6DF3008E7C9F /* Aztec.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F166A37B20EE6DD7008E7C9F /* Aztec.framework */; };
@@ -50,6 +53,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		7ECFA93B21C39B5000FC131B /* HeadingBlockFormatHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadingBlockFormatHandler.swift; sourceTree = "<group>"; };
+		7ECFA93F21C39BA000FC131B /* BlockFormatHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockFormatHandler.swift; sourceTree = "<group>"; };
+		7ECFA94121C39BBB00FC131B /* BlockModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockModel.swift; sourceTree = "<group>"; };
 		F1017BCE20ED1B1A002B1024 /* libReact.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libReact.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		F121467C20ED2F81003DD17B /* RCTAztecViewManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTAztecViewManager.m; sourceTree = "<group>"; };
 		F13BF49E20ECF5440047D3F9 /* RCTAztecView-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTAztecView-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -96,6 +102,9 @@
 				F121467C20ED2F81003DD17B /* RCTAztecViewManager.m */,
 				F13BF49F20ECF5450047D3F9 /* RCTAztecViewManager.swift */,
 				F1A879CF20EE90C000FABD31 /* RCTAztecView.swift */,
+				7ECFA94121C39BBB00FC131B /* BlockModel.swift */,
+				7ECFA93B21C39B5000FC131B /* HeadingBlockFormatHandler.swift */,
+				7ECFA93F21C39BA000FC131B /* BlockFormatHandler.swift */,
 			);
 			path = RNTAztecView;
 			sourceTree = "<group>";
@@ -207,9 +216,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7ECFA94021C39BA000FC131B /* BlockFormatHandler.swift in Sources */,
+				7ECFA93C21C39B5000FC131B /* HeadingBlockFormatHandler.swift in Sources */,
 				F13BF4A020ECF5450047D3F9 /* RCTAztecViewManager.swift in Sources */,
 				F1A879D020EE90C000FABD31 /* RCTAztecView.swift in Sources */,
 				F121467D20ED2F81003DD17B /* RCTAztecViewManager.m in Sources */,
+				7ECFA94221C39BBB00FC131B /* BlockModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/RNTAztecView/BlockFormatHandler.swift
+++ b/ios/RNTAztecView/BlockFormatHandler.swift
@@ -1,3 +1,7 @@
+
+/// Classes conforming this protocol are meant to do formatting work over an specific block.
+/// It is useful when we need to force an specific typing format that Aztec is not showing by default.
+///
 protocol BlockFormatHandler {
 
     /// Create an instance of a block formatter handler for the given block.

--- a/ios/RNTAztecView/BlockFormatHandler.swift
+++ b/ios/RNTAztecView/BlockFormatHandler.swift
@@ -1,0 +1,15 @@
+protocol BlockFormatHandler {
+
+    /// Create an instance of a block formatter handler for the given block.
+    /// If the given block is not compatible, the init will fail.
+    ///
+    init?(block: BlockModel)
+
+    /// Set the typing format to an specific one.
+    ///
+    func forceTypingFormat(with block: BlockModel, textView: RCTAztecView)
+
+    /// Change format of all the textview's content.
+    ///
+    func reformatContent(with block: BlockModel, textView: RCTAztecView)
+}

--- a/ios/RNTAztecView/BlockFormatHandler.swift
+++ b/ios/RNTAztecView/BlockFormatHandler.swift
@@ -7,9 +7,5 @@ protocol BlockFormatHandler {
 
     /// Set the typing format to an specific one.
     ///
-    func forceTypingFormat(with block: BlockModel, textView: RCTAztecView)
-
-    /// Change format of all the textview's content.
-    ///
-    func reformatContent(with block: BlockModel, textView: RCTAztecView)
+    func forceTypingFormat(on textView: RCTAztecView)
 }

--- a/ios/RNTAztecView/BlockModel.swift
+++ b/ios/RNTAztecView/BlockModel.swift
@@ -1,0 +1,3 @@
+struct BlockModel {
+    let tag: String
+}

--- a/ios/RNTAztecView/HeadingBlockFormatHandler.swift
+++ b/ios/RNTAztecView/HeadingBlockFormatHandler.swift
@@ -11,9 +11,18 @@ struct HeadingBlockFormatHandler: BlockFormatHandler {
     }
 
     func forceTypingFormat(on textView: RCTAztecView) {
+        textView.text = ensureNonEmptyString(textView.text)
         let attributes = textView.typingAttributesSwifted
         let formatter = HeaderFormatter(headerLevel: level)
         textView.typingAttributesSwifted = formatter.apply(to: attributes, andStore: nil)
+    }
+
+    private func ensureNonEmptyString(_ content: String) -> String {
+        let zeroWithSpace = String(Character.Name.zeroWidthSpace.rawValue)
+        guard content.isEmpty else {
+            return content.replacingOccurrences(of: zeroWithSpace, with: "")
+        }
+        return content.appending(zeroWithSpace)
     }
 
     private static func headerLevel(from levelString: String) -> Header.HeaderType? {

--- a/ios/RNTAztecView/HeadingBlockFormatHandler.swift
+++ b/ios/RNTAztecView/HeadingBlockFormatHandler.swift
@@ -10,24 +10,10 @@ struct HeadingBlockFormatHandler: BlockFormatHandler {
         self.level = level
     }
 
-    func forceTypingFormat(with block: BlockModel, textView: RCTAztecView) {
+    func forceTypingFormat(on textView: RCTAztecView) {
         let attributes = textView.typingAttributesSwifted
         let formatter = HeaderFormatter(headerLevel: level)
         textView.typingAttributesSwifted = formatter.apply(to: attributes, andStore: nil)
-    }
-
-    func reformatContent(with block: BlockModel, textView: RCTAztecView) {
-        resetTextViewContentWithoutHTMLTags(textView)
-        textView.toggleHeader(level, range: contentRange(of: textView))
-    }
-
-    private func resetTextViewContentWithoutHTMLTags(_ textView: RCTAztecView) {
-        let content = textView.text ?? ""
-        textView.setHTML(content) // needed to remove extra <p> tags.
-    }
-
-    private func contentRange(of textView: RCTAztecView) -> NSRange {
-        return NSRange(location: 0, length: textView.text.utf16.count)
     }
 
     private static func headerLevel(from levelString: String) -> Header.HeaderType? {

--- a/ios/RNTAztecView/HeadingBlockFormatHandler.swift
+++ b/ios/RNTAztecView/HeadingBlockFormatHandler.swift
@@ -1,0 +1,45 @@
+import Aztec
+
+struct HeadingBlockFormatHandler: BlockFormatHandler {
+    let level: Header.HeaderType
+
+    init?(block: BlockModel) {
+        guard let level = HeadingBlockFormatHandler.headerLevel(from: block.tag) else {
+            return nil
+        }
+        self.level = level
+    }
+
+    func forceTypingFormat(with block: BlockModel, textView: RCTAztecView) {
+        let attributes = textView.typingAttributesSwifted
+        let formatter = HeaderFormatter(headerLevel: level)
+        textView.typingAttributesSwifted = formatter.apply(to: attributes, andStore: nil)
+    }
+
+    func reformatContent(with block: BlockModel, textView: RCTAztecView) {
+        resetTextViewContentWithoutHTMLTags(textView)
+        textView.toggleHeader(level, range: contentRange(of: textView))
+    }
+
+    private func resetTextViewContentWithoutHTMLTags(_ textView: RCTAztecView) {
+        let content = textView.text ?? ""
+        textView.setHTML(content) // needed to remove extra <p> tags.
+    }
+
+    private func contentRange(of textView: RCTAztecView) -> NSRange {
+        return NSRange(location: 0, length: textView.text.utf16.count)
+    }
+
+    private static func headerLevel(from levelString: String) -> Header.HeaderType? {
+        switch levelString {
+        case "h2":
+            return .h2
+        case "h3":
+            return .h3
+        case "h4":
+            return .h4
+        default:
+            return nil
+        }
+    }
+}

--- a/ios/RNTAztecView/HeadingBlockFormatHandler.swift
+++ b/ios/RNTAztecView/HeadingBlockFormatHandler.swift
@@ -1,28 +1,25 @@
 import Aztec
 
 struct HeadingBlockFormatHandler: BlockFormatHandler {
-    let level: Header.HeaderType
+    private let level: Header.HeaderType
+    private let paragraphFormatter = HTMLParagraphFormatter(placeholderAttributes: nil)
+    private let headerFormatter: HeaderFormatter
 
     init?(block: BlockModel) {
         guard let level = HeadingBlockFormatHandler.headerLevel(from: block.tag) else {
             return nil
         }
         self.level = level
+        headerFormatter = HeaderFormatter(headerLevel: level)
     }
 
     func forceTypingFormat(on textView: RCTAztecView) {
-        textView.text = ensureNonEmptyString(textView.text)
-        let attributes = textView.typingAttributesSwifted
-        let formatter = HeaderFormatter(headerLevel: level)
-        textView.typingAttributesSwifted = formatter.apply(to: attributes, andStore: nil)
-    }
+        var attributes = textView.typingAttributesSwifted
 
-    private func ensureNonEmptyString(_ content: String) -> String {
-        let zeroWithSpace = String(Character.Name.zeroWidthSpace.rawValue)
-        guard content.isEmpty else {
-            return content.replacingOccurrences(of: zeroWithSpace, with: "")
-        }
-        return content.appending(zeroWithSpace)
+        attributes = paragraphFormatter.remove(from: attributes)
+        attributes = headerFormatter.apply(to: attributes, andStore: nil)
+
+        textView.typingAttributesSwifted = attributes
     }
 
     private static func headerLevel(from levelString: String) -> Header.HeaderType? {

--- a/ios/RNTAztecView/RCTAztecView.swift
+++ b/ios/RNTAztecView/RCTAztecView.swift
@@ -21,11 +21,7 @@ class RCTAztecView: Aztec.TextView {
         }
     }
 
-    var blockModel = BlockModel(tag: "") {
-        didSet {
-            handleBlockTypeChangeIfNeeded(with: blockModel)
-        }
-    }
+    var blockModel = BlockModel(tag: "")
 
     private var previousContentSize: CGSize = .zero
 
@@ -164,7 +160,7 @@ class RCTAztecView: Aztec.TextView {
         }
         
         let html = contents["text"] as? String ?? ""
-        
+
         setHTML(html)
         updatePlaceholderVisibility()
     }
@@ -234,15 +230,9 @@ class RCTAztecView: Aztec.TextView {
         return attributes
     }
 
-    func handleBlockTypeChangeIfNeeded(with block: BlockModel) {
-        if let formatHandler = HeadingBlockFormatHandler(block: block) {
-            formatHandler.reformatContent(with: block, textView: self)
-        }
-    }
-
     func forceTypingAttributesIfNeeded() {
         if let formatHandler = HeadingBlockFormatHandler(block: blockModel) {
-            formatHandler.forceTypingFormat(with: blockModel, textView: self)
+            formatHandler.forceTypingFormat(on: self)
         }
     }
     
@@ -311,6 +301,4 @@ extension RCTAztecView: UITextViewDelegate {
     func textViewDidEndEditing(_ textView: UITextView) {
         onBlur?([:])
     }
-
 }
-

--- a/ios/RNTAztecView/RCTAztecView.swift
+++ b/ios/RNTAztecView/RCTAztecView.swift
@@ -21,7 +21,11 @@ class RCTAztecView: Aztec.TextView {
         }
     }
 
-    var blockModel = BlockModel(tag: "")
+    var blockModel = BlockModel(tag: "") {
+        didSet {
+            forceTypingAttributesIfNeeded()
+        }
+    }
 
     private var previousContentSize: CGSize = .zero
 

--- a/ios/RNTAztecView/RCTAztecView.swift
+++ b/ios/RNTAztecView/RCTAztecView.swift
@@ -12,6 +12,20 @@ class RCTAztecView: Aztec.TextView {
     @objc var onSelectionChange: RCTBubblingEventBlock? = nil
     @objc var onActiveFormatsChange: RCTBubblingEventBlock? = nil
     @objc var onActiveFormatAttributesChange: RCTBubblingEventBlock? = nil
+    @objc var blockType: NSDictionary? = nil {
+        didSet {
+            guard let block = blockType, let tag = block["tag"] as? String else {
+                return
+            }
+            blockModel = BlockModel(tag: tag)
+        }
+    }
+
+    var blockModel = BlockModel(tag: "") {
+        didSet {
+            handleBlockTypeChangeIfNeeded(with: blockModel)
+        }
+    }
 
     private var previousContentSize: CGSize = .zero
 
@@ -219,6 +233,18 @@ class RCTAztecView: Aztec.TextView {
         }
         return attributes
     }
+
+    func handleBlockTypeChangeIfNeeded(with block: BlockModel) {
+        if let formatHandler = HeadingBlockFormatHandler(block: block) {
+            formatHandler.reformatContent(with: block, textView: self)
+        }
+    }
+
+    func forceTypingAttributesIfNeeded() {
+        if let formatHandler = HeadingBlockFormatHandler(block: blockModel) {
+            formatHandler.forceTypingFormat(with: blockModel, textView: self)
+        }
+    }
     
     // MARK: - Event Propagation
     
@@ -273,6 +299,7 @@ extension RCTAztecView: UITextViewDelegate {
     }
 
     func textViewDidChange(_ textView: UITextView) {
+        forceTypingAttributesIfNeeded()
         propagateFormatChanges()
         propagateContentChanges()
     }

--- a/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/ios/RNTAztecView/RCTAztecViewManager.m
@@ -10,6 +10,7 @@ RCT_EXPORT_VIEW_PROPERTY(onEnter, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFocus, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onBlur, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onSelectionChange, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(blockType, NSDictionary)
 
 RCT_EXPORT_VIEW_PROPERTY(onActiveFormatsChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onActiveFormatAttributesChange, RCTBubblingEventBlock)

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -27,6 +27,7 @@ class AztecView extends React.Component {
     onActiveFormatAttributesChange: PropTypes.func,
     onSelectionChange: PropTypes.func,
     onHTMLContentWithCursor: PropTypes.func,
+    blockType: PropTypes.object,
     ...ViewPropTypes, // include the default view properties
   }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/355

This PR forces the typing attributes to be corresponding with the Heading level, when Aztec is used to display Heading blocks.

With @diegoreymendez we looked into the possibility of fixing this on the Aztec level but it easily became super complicated. So we decided for an RNAztecView approach.

The `BlockFormatHandler` and `BlockModel` are meant to be easily extensible, in case we need similar implementations with other blocks in the future.

### Refertences:
`mobile-gutenberg` branch: `issue/ios-heading-behavior`
`gutenberg` PR: https://github.com/WordPress/gutenberg/pull/12869
`Aztec-iOS` PR https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1108


![heading](https://user-images.githubusercontent.com/9772967/49995945-50c40100-ff96-11e8-80e7-399357910c87.gif)


To Test:

**Setup:**
- Checkout `gutenberg-mobile` branch `issue/ios-heading-behavior`.
- Run `git submodule update` to checkout submodules commits.
- Run `yarn preios` to force update the Aztec version.
- Run `yarn start:reset`
- Open the iOS example project on Xcode `open ios/gutenberg.xcodeproj`.
- Clean build folder.
- Build and run (from Xcode or from `yarn ios`)

**Testing:**
- Create a Heading block.
- Check that the heading block style is the correct.
- Type and delete text, change Heading levels, etc...
- Check that everything looks fine.
- Format a word of the title with Italic and change Heading levels.
- Make sure that the Italic format is not removed.
  - Bold has an issue but is already solved on master.

Thank you!