### PR TITLE
Feature/set remove link interface android

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecFormattingAttributesChange.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecFormattingAttributesChange.java
@@ -1,5 +1,7 @@
 package org.wordpress.mobile.ReactNativeAztec;
 
+import android.text.TextUtils;
+
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
@@ -12,6 +14,23 @@ import com.facebook.react.uimanager.events.RCTEventEmitter;
 public class ReactAztecFormattingAttributesChange extends Event<ReactAztecFormattingChangeEvent> {
 
     private static final String EVENT_NAME = "topFormatAttributeChanges";
+
+    private static final String KEY_EVENT_DATA_ATTRIBUTES = "attributes";
+
+    private static final String KEY_ATTRIBUTES_DATA_LINK = "link";
+
+    private static final String KEY_LINK_DATA_IS_ACTIVE = "isActive";
+    private static final String KEY_LINK_DATA_IS_URL = "url";
+
+    private String mUrl;
+
+    public ReactAztecFormattingAttributesChange(int viewId) {
+        super(viewId);
+    }
+
+    public void setLinkData(String url) {
+        mUrl = url;
+    }
 
     @Override
     public String getEventName() {
@@ -30,16 +49,24 @@ public class ReactAztecFormattingAttributesChange extends Event<ReactAztecFormat
 
     private WritableMap serializeEventData() {
 
-        WritableMap linkData = Arguments.createMap();
-        linkData.putBoolean("isActive", true);
-        linkData.putString("url", "wp.com");
-
         WritableMap attributesData = Arguments.createMap();
-        attributesData.putMap("link", linkData);
+        attributesData.putMap(KEY_ATTRIBUTES_DATA_LINK, getLinkData());
 
         WritableMap eventData = Arguments.createMap();
-        eventData.putMap("attributes", attributesData);
+        eventData.putMap(KEY_EVENT_DATA_ATTRIBUTES, attributesData);
 
         return eventData;
+    }
+
+    private WritableMap getLinkData() {
+        WritableMap linkData = Arguments.createMap();
+        if (!TextUtils.isEmpty(mUrl)) {
+            linkData.putBoolean(KEY_LINK_DATA_IS_ACTIVE, true);
+            linkData.putString(KEY_LINK_DATA_IS_URL, mUrl);
+        }
+        else {
+            linkData.putBoolean(KEY_LINK_DATA_IS_ACTIVE, false);
+        }
+        return linkData;
     }
 }

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecFormattingAttributesChange.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecFormattingAttributesChange.java
@@ -1,0 +1,45 @@
+package org.wordpress.mobile.ReactNativeAztec;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted by Aztec native view when attributes detected.
+ */
+
+public class ReactAztecFormattingAttributesChange extends Event<ReactAztecFormattingChangeEvent> {
+
+    private static final String EVENT_NAME = "topFormatAttributeChanges";
+
+    @Override
+    public String getEventName() {
+        return EVENT_NAME;
+    }
+
+    @Override
+    public boolean canCoalesce() {
+        return false;
+    }
+
+    @Override
+    public void dispatch(RCTEventEmitter rctEventEmitter) {
+        rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+    }
+
+    private WritableMap serializeEventData() {
+
+        WritableMap linkData = Arguments.createMap();
+        linkData.putBoolean("isActive", true);
+        linkData.putString("url", "wp.com");
+
+        WritableMap attributesData = Arguments.createMap();
+        attributesData.putMap("link", linkData);
+
+        WritableMap eventData = Arguments.createMap();
+        eventData.putMap("attributes", attributesData);
+
+        return eventData;
+    }
+}

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -105,6 +105,11 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
                                 "phasedRegistrationNames",
                                 MapBuilder.of("bubbled", "onActiveFormatsChange")))
                 .put(
+                        "topFormatAttributeChanges",
+                        MapBuilder.of(
+                                "phasedRegistrationNames",
+                                MapBuilder.of("bubbled", "onActiveFormatAttributesChange")))
+                .put(
                         "topEndEditing",
                         MapBuilder.of(
                                 "phasedRegistrationNames",
@@ -259,6 +264,11 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
         view.shouldHandleActiveFormatsChange = onActiveFormatsChange;
     }
 
+    @ReactProp(name = "onActiveFormatAttributesChange", defaultBoolean = false)
+    public void setOnActiveFormatAttributesChange(final ReactAztecText view, boolean onActiveFormatAttributesChange) {
+        view.shouldHandleActiveFormatAttributesChange = onActiveFormatAttributesChange;
+    }
+
     @ReactProp(name = "onSelectionChange", defaultBoolean = false)
     public void setOnSelectionChange(final ReactAztecText view, boolean onSelectionChange) {
         view.shouldHandleOnSelectionChange = onSelectionChange;
@@ -281,6 +291,16 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
     @ReactProp(name = "onBackspace", defaultBoolean = false)
     public void setOnBackspaceHandling(final ReactAztecText view, boolean onBackspaceHandling) {
         view.shouldHandleOnBackspace = onBackspaceHandling;
+    }
+
+    @ReactProp(name = "setLink", defaultBoolean = false)
+    public void setLink(final ReactAztecText view, String url, String title) {
+        view.link(url, title, false);
+    }
+
+    @ReactProp(name = "removeLink", defaultBoolean = false)
+    public void removeLink(final ReactAztecText view) {
+        view.removeLink();
     }
 
     @Override

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -303,7 +303,7 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
                 .put("applyFormat", COMMAND_NOTIFY_APPLY_FORMAT)
                 .put("focusTextInput", mFocusTextInputCommandCode)
                 .put("blurTextInput", mBlurTextInputCommandCode)
-                .put("setLink", COMMAND_NOTIFY_SET_LINK)
+                .put("setLinkData", COMMAND_NOTIFY_SET_LINK)
                 .put("removeLink", COMMAND_NOTIFY_REMOVE_LINK)
                 .build();
     }

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -326,7 +326,7 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
         else if (commandType == COMMAND_NOTIFY_SET_LINK) {
             final String url = args.getString(0);
             final String title = args.getString(1);
-            parent.link(url, title, false);
+            parent.link(url, title);
             return;
         }
         else if (commandType == COMMAND_NOTIFY_REMOVE_LINK) {

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -10,6 +10,7 @@ import android.view.View;
 
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
@@ -47,6 +48,9 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
     private static final int FOCUS_TEXT_INPUT = 1;
     private static final int BLUR_TEXT_INPUT = 2;
     private static final int COMMAND_NOTIFY_APPLY_FORMAT = 100;
+    private static final int COMMAND_NOTIFY_SET_LINK = 101;
+    private static final int COMMAND_NOTIFY_REMOVE_LINK = 102;
+
 
     // we define the same codes in ReactAztecText as they have for ReactNative's TextInput, so
     // it's easier to handle focus between Aztec and TextInput instances on the same screen.
@@ -293,22 +297,14 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
         view.shouldHandleOnBackspace = onBackspaceHandling;
     }
 
-    @ReactProp(name = "setLink", defaultBoolean = false)
-    public void setLink(final ReactAztecText view, String url, String title) {
-        view.link(url, title, false);
-    }
-
-    @ReactProp(name = "removeLink", defaultBoolean = false)
-    public void removeLink(final ReactAztecText view) {
-        view.removeLink();
-    }
-
     @Override
     public Map<String, Integer> getCommandsMap() {
         return MapBuilder.<String, Integer>builder()
                 .put("applyFormat", COMMAND_NOTIFY_APPLY_FORMAT)
                 .put("focusTextInput", mFocusTextInputCommandCode)
                 .put("blurTextInput", mBlurTextInputCommandCode)
+                .put("setLink", COMMAND_NOTIFY_SET_LINK)
+                .put("removeLink", COMMAND_NOTIFY_REMOVE_LINK)
                 .build();
     }
 
@@ -325,6 +321,16 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
             return;
         } else if (commandType == mBlurTextInputCommandCode) {
             parent.clearFocusFromJS();
+            return;
+        }
+        else if (commandType == COMMAND_NOTIFY_SET_LINK) {
+            final String url = args.getString(0);
+            final String title = args.getString(1);
+            parent.link(url, title, false);
+            return;
+        }
+        else if (commandType == COMMAND_NOTIFY_REMOVE_LINK) {
+            parent.removeLink();
             return;
         }
         super.receiveCommand(parent, commandType, args);

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -10,7 +10,6 @@ import android.view.View;
 
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -303,7 +303,7 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
                 .put("applyFormat", COMMAND_NOTIFY_APPLY_FORMAT)
                 .put("focusTextInput", mFocusTextInputCommandCode)
                 .put("blurTextInput", mBlurTextInputCommandCode)
-                .put("setLinkData", COMMAND_NOTIFY_SET_LINK)
+                .put("setLink", COMMAND_NOTIFY_SET_LINK)
                 .put("removeLink", COMMAND_NOTIFY_REMOVE_LINK)
                 .build();
     }

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -412,6 +412,7 @@ public class ReactAztecText extends AztecText {
             title = getSelectedText();
         }
         link(url, title, false);
+        applyFormat("link");
     }
 
     /**

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -6,7 +6,6 @@ import android.support.annotation.Nullable;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.inputmethod.InputMethodManager;
 
 import com.facebook.infer.annotation.Assertions;
@@ -227,17 +226,6 @@ public class ReactAztecText extends AztecText {
                     )
             );
         }
-
-        if (shouldHandleActiveFormatAttributesChange) {
-            ReactContext reactContext = (ReactContext) getContext();
-            EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
-//            eventDispatcher.dispatchEvent(
-//                    new ReactAztecFormattingAttributesChange(
-//                            getId(),
-//                            formattingOptions.toArray(new String[formattingOptions.size()])
-//                    )
-//            );
-        }
     }
 
     private void propagateSelectionChanges(int selStart, int selEnd) {
@@ -254,7 +242,14 @@ public class ReactAztecText extends AztecText {
 
     private void propagateAttributesChange() {
         Triple<String, String, Boolean> triple = linkFormatter.getSelectedUrlWithAnchor();
-
+        if (shouldHandleActiveFormatAttributesChange) {
+            ReactContext reactContext = (ReactContext) getContext();
+            EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+            ReactAztecFormattingAttributesChange reactAztecFormattingAttributesChange =
+                    new ReactAztecFormattingAttributesChange(getId());
+            reactAztecFormattingAttributesChange.setLinkData(triple.getFirst());
+            eventDispatcher.dispatchEvent(reactAztecFormattingAttributesChange);
+        }
     }
 
     @Override

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.support.annotation.Nullable;
 import android.text.Editable;
+import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.view.inputmethod.InputMethodManager;
@@ -253,7 +254,7 @@ public class ReactAztecText extends AztecText {
 
     private void propagateAttributesChange() {
         Triple<String, String, Boolean> triple = linkFormatter.getSelectedUrlWithAnchor();
-        Log.e("ivasavic", "test");
+
     }
 
     @Override
@@ -404,6 +405,13 @@ public class ReactAztecText extends AztecText {
         }
 
         return textFormats;
+    }
+
+    public void link (String url, String title) {
+        if (TextUtils.isEmpty(title)) {
+            title = getSelectedText();
+        }
+        link(url, title, false);
     }
 
     /**

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -241,13 +241,12 @@ public class ReactAztecText extends AztecText {
     }
 
     private void propagateAttributesChange() {
-        Triple<String, String, Boolean> triple = linkFormatter.getSelectedUrlWithAnchor();
         if (shouldHandleActiveFormatAttributesChange) {
             ReactContext reactContext = (ReactContext) getContext();
             EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
             ReactAztecFormattingAttributesChange reactAztecFormattingAttributesChange =
                     new ReactAztecFormattingAttributesChange(getId());
-            reactAztecFormattingAttributesChange.setLinkData(triple.getFirst());
+            reactAztecFormattingAttributesChange.setLinkData(linkFormatter.getSelectedUrlWithAnchor().getFirst());
             eventDispatcher.dispatchEvent(reactAztecFormattingAttributesChange);
         }
     }

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -27,8 +27,6 @@ import org.wordpress.aztec.plugins.IToolbarButton;
 import java.util.ArrayList;
 import java.util.LinkedList;
 
-import kotlin.Triple;
-
 public class ReactAztecText extends AztecText {
 
     private final InputMethodManager mInputMethodManager;


### PR DESCRIPTION
This PR is inspired by iOS implementation which was described in [this PR](https://github.com/wordpress-mobile/react-native-aztec/pull/87).

![ezgif-2-c101c8c4967b](https://user-images.githubusercontent.com/28219092/50034708-784eb400-fffe-11e8-95a3-9f4a5167022d.gif)

In the branch `gutenberg/rnmobile/test-links` you can find a testing code, and see how it looks:
https://github.com/WordPress/gutenberg/compare/mobile...rnmobile/test-links