### PR TITLE
Fix for new line added on Enter.key

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -91,10 +91,10 @@ repositories {
 }
 
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:fbf294b88d17996aff9e3d62a293d2638818dd0a')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:fbf294b88d17996aff9e3d62a293d2638818dd0a')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:fbf294b88d17996aff9e3d62a293d2638818dd0a')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:fbf294b88d17996aff9e3d62a293d2638818dd0a')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:254feae6f05587a1b1614ba1527038c25d75ee4a')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:254feae6f05587a1b1614ba1527038c25d75ee4a')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:254feae6f05587a1b1614ba1527038c25d75ee4a')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:254feae6f05587a1b1614ba1527038c25d75ee4a')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 


### PR DESCRIPTION
This PR upgrades the Aztec ref, and fixes an issue where the `onEnterKey` listener was called when the wrong text that contained the `\n` character in it was already set in the Aztec editor.

Aztec PR here: https://github.com/wordpress-mobile/AztecEditor-Android/pull/768

Testing steps in gb-mobile PR available here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/401