### PR TITLE
Avoid testing for focus if there is nothing focused

### DIFF
--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -151,7 +151,8 @@ class AztecView extends React.Component {
   }
 
   isFocused = () => {
-    return TextInputState.currentlyFocusedField() === ReactNative.findNodeHandle(this);
+    const focusedField = TextInputState.currentlyFocusedField();
+    return focusedField && ( focusedField === ReactNative.findNodeHandle(this) );
   }
 
   _onPress = (event) => {


### PR DESCRIPTION
Fixes some problems with the test renderer calling this. There was something wrong in the Jest test isolation in https://github.com/wordpress-mobile/gutenberg-mobile/pull/423, it was calling when this was unmounted with a null focused field