### PR TITLE
Use a view props instead to update the currently selected formats

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         wordpressUtilsVersion = '1.22'
         espressoVersion = '3.0.1'
 
-        aztecVersion = 'v1.3.14'
+        aztecVersion = 'v1.3.16'
     }
 
     repositories {

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -39,6 +39,8 @@ import org.wordpress.aztec.plugins.wpcomments.WordPressCommentsPlugin;
 import org.wordpress.aztec.plugins.wpcomments.toolbar.MoreToolbarButton;
 
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
@@ -46,7 +48,6 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
 
     private static final int FOCUS_TEXT_INPUT = 1;
     private static final int BLUR_TEXT_INPUT = 2;
-    private static final int COMMAND_NOTIFY_APPLY_FORMAT = 100;
 
     // we define the same codes in ReactAztecText as they have for ReactNative's TextInput, so
     // it's easier to handle focus between Aztec and TextInput instances on the same screen.
@@ -171,6 +172,19 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
         view.setIsSettingTextFromJS(false);
     }
 
+    @ReactProp(name = "activeFormats", defaultBoolean = false)
+    public void setActiveFormats(final ReactAztecText view, @Nullable ReadableArray activeFormats) {
+        if (activeFormats != null) {
+            String[] activeFormatsArray = new String[activeFormats.size()];
+            for (int i = 0; i < activeFormats.size(); i++) {
+                activeFormatsArray[i] = activeFormats.getString(i);
+            }
+            view.setActiveFormats(Arrays.asList(activeFormatsArray));
+        } else {
+            view.setActiveFormats(new ArrayList<String>());
+        }
+    }
+
     @ReactProp(name = "color", customType = "Color")
     public void setColor(ReactAztecText view, @Nullable Integer color) {
         int newColor = Color.BLACK;
@@ -254,11 +268,6 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
         }
     }
 
-    @ReactProp(name = "onActiveFormatsChange", defaultBoolean = false)
-    public void setOnActiveFormatsChange(final ReactAztecText view, boolean onActiveFormatsChange) {
-        view.shouldHandleActiveFormatsChange = onActiveFormatsChange;
-    }
-
     @ReactProp(name = "onSelectionChange", defaultBoolean = false)
     public void setOnSelectionChange(final ReactAztecText view, boolean onSelectionChange) {
         view.shouldHandleOnSelectionChange = onSelectionChange;
@@ -286,7 +295,6 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
     @Override
     public Map<String, Integer> getCommandsMap() {
         return MapBuilder.<String, Integer>builder()
-                .put("applyFormat", COMMAND_NOTIFY_APPLY_FORMAT)
                 .put("focusTextInput", mFocusTextInputCommandCode)
                 .put("blurTextInput", mBlurTextInputCommandCode)
                 .build();
@@ -295,12 +303,7 @@ public class ReactAztecManager extends SimpleViewManager<ReactAztecText> {
     @Override
     public void receiveCommand(final ReactAztecText parent, int commandType, @Nullable ReadableArray args) {
         Assertions.assertNotNull(parent);
-        if (commandType == COMMAND_NOTIFY_APPLY_FORMAT) {
-            final String format = args.getString(0);
-            Log.d(TAG, String.format("Apply format: %s", format));
-            parent.applyFormat(format);
-            return;
-        } else if (commandType == mFocusTextInputCommandCode) {
+        if (commandType == mFocusTextInputCommandCode) {
             parent.requestFocusFromJS();
             return;
         } else if (commandType == mBlurTextInputCommandCode) {

--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -26,6 +26,10 @@ import org.wordpress.aztec.plugins.IToolbarButton;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.HashMap;
 
 public class ReactAztecText extends AztecText {
 
@@ -51,6 +55,16 @@ public class ReactAztecText extends AztecText {
     boolean shouldHandleOnBackspace = false;
     boolean shouldHandleOnSelectionChange = false;
     boolean shouldHandleActiveFormatsChange = false;
+
+    private static final HashMap<ITextFormat, String> typingFormatsMap = new HashMap<ITextFormat, String>() {
+        {
+            put(AztecTextFormat.FORMAT_BOLD, "bold");
+            put(AztecTextFormat.FORMAT_STRONG, "bold");
+            put(AztecTextFormat.FORMAT_ITALIC, "italic");
+            put(AztecTextFormat.FORMAT_CITE, "italic");
+            put(AztecTextFormat.FORMAT_STRIKETHROUGH, "bold");
+        }
+    };
 
     public ReactAztecText(ThemedReactContext reactContext) {
         super(reactContext);
@@ -316,66 +330,27 @@ public class ReactAztecText extends AztecText {
         return true;
     }
 
-    public void applyFormat(String format) {
-        ArrayList<ITextFormat> newFormats = new ArrayList<>();
-        switch (format) {
-            case ("bold"):
-            case ("strong"):
-                newFormats.add(AztecTextFormat.FORMAT_STRONG);
-                newFormats.add(AztecTextFormat.FORMAT_BOLD);
-            break;
-            case ("italic"):
-                newFormats.add(AztecTextFormat.FORMAT_ITALIC);
-                newFormats.add(AztecTextFormat.FORMAT_CITE);
-            break;
-            case ("strikethrough"):
-                newFormats.add(AztecTextFormat.FORMAT_STRIKETHROUGH);
-            break;
-        }
-
-        if (newFormats.size() == 0) {
-            return;
-        }
-
-        if (!isTextSelected()) {
-            final ArrayList<ITextFormat> newStylesList = getNewStylesList(newFormats);
-            setSelectedStyles(newStylesList);
-            // Update the toolbar state
-            updateToolbarButtons(newStylesList);
-        } else {
-            toggleFormatting(newFormats.get(0));
-            // Update the toolbar state
-            updateToolbarButtons(getSelectionStart(), getSelectionEnd());
-        }
-
-        // emit onChange because the underlying HTML has changed applying the style
-        ReactContext reactContext = (ReactContext) getContext();
-        EventDispatcher eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
-        eventDispatcher.dispatchEvent(
-                new ReactTextChangedEvent(
-                        getId(),
-                        toHtml(false),
-                        incrementAndGetEventCounter())
-        );
-    }
-
-    // Removes all formats in the list but if none found, applies the first one
-    private ArrayList<ITextFormat> getNewStylesList(ArrayList<ITextFormat> newFormats) {
-        ArrayList<ITextFormat> textFormats = new ArrayList<>();
-        textFormats.addAll(getSelectedStyles());
-        boolean wasRemoved = false;
-        for (ITextFormat newFormat : newFormats) {
-            if (textFormats.contains(newFormat)) {
-                wasRemoved = true;
-                textFormats.remove(newFormat);
+    public void setActiveFormats(Iterable<String> newFormats) {
+        Set<ITextFormat> selectedStylesSet = new HashSet<>(getSelectedStyles());
+        Set<ITextFormat> newFormatsSet = new HashSet<>();
+        for (String newFormat : newFormats) {
+            switch (newFormat) {
+                case "bold":
+                    newFormatsSet.add(AztecTextFormat.FORMAT_STRONG);
+                    break;
+                case "italic":
+                    newFormatsSet.add(AztecTextFormat.FORMAT_CITE);
+                    break;
+                case "strikethrough":
+                    newFormatsSet.add(AztecTextFormat.FORMAT_STRIKETHROUGH);
+                    break;
             }
         }
-
-        if (!wasRemoved) {
-            textFormats.add(newFormats.get(0));
-        }
-
-        return textFormats;
+        selectedStylesSet.removeAll(typingFormatsMap.keySet());
+        selectedStylesSet.addAll(newFormatsSet);
+        ArrayList<ITextFormat> newStylesList = new ArrayList<>(selectedStylesSet);
+        setSelectedStyles(newStylesList);
+        updateToolbarButtons(newStylesList);
     }
 
     /**

--- a/ios/RNTAztecView/RCTAztecView.swift
+++ b/ios/RNTAztecView/RCTAztecView.swift
@@ -22,7 +22,7 @@ class RCTAztecView: Aztec.TextView {
         didSet {
             let currentTypingAttributes = formattingIdentifiersForTypingAttributes()
             for (key, value) in formatStringMap where currentTypingAttributes.contains(key) != activeFormats?.contains(value) {
-                    apply(format: value)
+                toggleFormat(format: value)
             }
         }
     }
@@ -212,11 +212,12 @@ class RCTAztecView: Aztec.TextView {
 
     // MARK: - Formatting interface
 
-    @objc func apply(format: String) {
+    @objc func toggleFormat(format: String) {
+        let emptyRange = NSRange(location: selectedRange.location, length: 0)
         switch format {
-        case "bold": toggleBold(range: selectedRange)
-        case "italic": toggleItalic(range: selectedRange)
-        case "strikethrough": toggleStrikethrough(range: selectedRange)
+        case "bold": toggleBold(range: emptyRange)
+        case "italic": toggleItalic(range: emptyRange)
+        case "strikethrough": toggleStrikethrough(range: emptyRange)
         default: print("Format not recognized")
         }
     }

--- a/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/ios/RNTAztecView/RCTAztecViewManager.m
@@ -11,6 +11,7 @@ RCT_EXPORT_VIEW_PROPERTY(onFocus, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onBlur, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onSelectionChange, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(blockType, NSDictionary)
+RCT_EXPORT_VIEW_PROPERTY(activeFormats, NSSet)
 
 RCT_EXPORT_VIEW_PROPERTY(onActiveFormatsChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onActiveFormatAttributesChange, RCTBubblingEventBlock)

--- a/ios/RNTAztecView/RCTAztecViewManager.swift
+++ b/ios/RNTAztecView/RCTAztecViewManager.swift
@@ -12,27 +12,6 @@ public class RCTAztecViewManager: RCTViewManager {
     }
 
     @objc
-    func applyFormat(_ node: NSNumber, format: String) {
-        executeBlock({ (aztecView) in
-            aztecView.apply(format: format)
-        }, onNode: node)
-    }
-
-    @objc
-    func removeLink(_ node: NSNumber) {
-        executeBlock({ (aztecView) in
-            aztecView.removeLink()
-        }, onNode: node)
-    }
-
-    @objc
-    func setLink(_ node: NSNumber, url: String, title: String?) {
-        executeBlock({ (aztecView) in
-            aztecView.setLink(with: url, and: title)
-        }, onNode: node)
-    }
-
-    @objc
     public override func view() -> UIView {
         let view = RCTAztecView(
             defaultFont: defaultFont,

--- a/src/AztecView.js
+++ b/src/AztecView.js
@@ -9,6 +9,7 @@ class AztecView extends React.Component {
   selectionEndCaretY: number;
 
   static propTypes = {
+    activeFormats: PropTypes.array,
     isSelected: PropTypes.bool,
     disableGutenbergMode: PropTypes.bool,
     text: PropTypes.object,
@@ -24,8 +25,6 @@ class AztecView extends React.Component {
     onEnter: PropTypes.func,
     onBackspace: PropTypes.func,
     onScroll: PropTypes.func,
-    onActiveFormatsChange: PropTypes.func,
-    onActiveFormatAttributesChange: PropTypes.func,
     onSelectionChange: PropTypes.func,
     onHTMLContentWithCursor: PropTypes.func,
     onCaretVerticalPositionChange: PropTypes.func,
@@ -42,38 +41,8 @@ class AztecView extends React.Component {
     );
   }
 
-  applyFormat(format) {
-    this.dispatch(AztecManager.Commands.applyFormat, [format])
-  }
-
-  removeLink() {
-    this.dispatch(AztecManager.Commands.removeLink)
-  }
-
-  setLink(url, title) {
-    this.dispatch(AztecManager.Commands.setLink, [url, title])
-  }
-
   requestHTMLWithCursor() {
     this.dispatch(AztecManager.Commands.returnHTMLWithCursor)
-  }
-
-  _onActiveFormatsChange = (event) => {
-    if (!this.props.onActiveFormatsChange) {
-      return;
-    }
-    const formats = event.nativeEvent.formats;
-    const { onActiveFormatsChange } = this.props;
-    onActiveFormatsChange(formats);
-  }
-
-  _onActiveFormatAttributesChange = (event) => {
-    if (!this.props.onActiveFormatAttributesChange) {
-      return;
-    }
-    const attributes = event.nativeEvent.attributes;
-    const { onActiveFormatAttributesChange } = this.props;
-    onActiveFormatAttributesChange(attributes);
   }
 
   _onContentSizeChange = (event) => {
@@ -174,8 +143,6 @@ class AztecView extends React.Component {
     return (
       <TouchableWithoutFeedback onPress={ this._onPress }>
         <RCTAztecView {...otherProps}
-          onActiveFormatsChange={ this._onActiveFormatsChange }
-          onActiveFormatAttributesChange={ this._onActiveFormatAttributesChange }
           onContentSizeChange = { this._onContentSizeChange }
           onHTMLContentWithCursor = { this._onHTMLContentWithCursor }
           onSelectionChange = { this._onSelectionChange }


### PR DESCRIPTION
This PR removes our existing formatting callbacks (`onActiveFormatsChange` and `onActiveFormatAttributesChange `) and uses a view props (`activeFormats`) instead to update the currently selected formats.

With https://github.com/WordPress/gutenberg/pull/12249 the formatting will be handled over to gutenberg's format-library and Aztec will be "mostly" rendering the HTML. However, we also want to be able to render formatted text without delay, thus we need Aztec to be able to edit a rich text directly without formatting changes while the text entered cycles back to RN.

FYI, this "feature" is added to the format-library PR with [this commit](https://github.com/WordPress/gutenberg/pull/12249/commits/f3188d927f50c153ecc9b3c35fe92658af85755d).

I'm not a Swift programmer so I'm interested in your feedback and really welcome contributions on this one :)

**Edit:** Added an implementation for Android but it's currently buggy