### PR TITLE
Point to Aztec with fix for backspace on paste

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -87,10 +87,10 @@ repositories {
 }
 
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:c0ad0b04f0abe94d931a624ffd16ca4bf8802f1e')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:c0ad0b04f0abe94d931a624ffd16ca4bf8802f1e')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:c0ad0b04f0abe94d931a624ffd16ca4bf8802f1e')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:c0ad0b04f0abe94d931a624ffd16ca4bf8802f1e')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:d8675f5c617b9816f836d687e1af0321c2130063')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:d8675f5c617b9816f836d687e1af0321c2130063')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:d8675f5c617b9816f836d687e1af0321c2130063')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:d8675f5c617b9816f836d687e1af0321c2130063')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -87,10 +87,10 @@ repositories {
 }
 
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:b3949f1ed8739919563aac1326d87fb7944bf6bb')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:b3949f1ed8739919563aac1326d87fb7944bf6bb')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:b3949f1ed8739919563aac1326d87fb7944bf6bb')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:b3949f1ed8739919563aac1326d87fb7944bf6bb')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:c0ad0b04f0abe94d931a624ffd16ca4bf8802f1e')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:c0ad0b04f0abe94d931a624ffd16ca4bf8802f1e')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:c0ad0b04f0abe94d931a624ffd16ca4bf8802f1e')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:c0ad0b04f0abe94d931a624ffd16ca4bf8802f1e')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -87,10 +87,10 @@ repositories {
 }
 
 dependencies {
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.3.13')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.3.13')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.3.13')
-    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:v1.3.13')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:b3949f1ed8739919563aac1326d87fb7944bf6bb')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:b3949f1ed8739919563aac1326d87fb7944bf6bb')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:b3949f1ed8739919563aac1326d87fb7944bf6bb')
+    api ('com.github.wordpress-mobile.WordPress-Aztec-Android:glide-loader:b3949f1ed8739919563aac1326d87fb7944bf6bb')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         gradlePluginVersion = '3.0.1'
         kotlinVersion = '1.2.31'
         supportLibVersion = '27.1.1'
-        tagSoupVersion = '1.2.2'
+        tagSoupVersion = '1.2.1'
         glideVersion = '3.7.0'
         picassoVersion = '2.5.2'
         robolectricVersion = '3.5.1'


### PR DESCRIPTION
This PR adds the fix for https://github.com/wordpress-mobile/gutenberg-mobile/issues/430.

To test:

Use https://github.com/wordpress-mobile/gutenberg-mobile/pull/456 to test out the fix.

This PR will get updated after https://github.com/wordpress-mobile/AztecEditor-Android/pull/771 gets merged to point to the new ref.