### PR TITLE
Fix Aztec Wrapper single line on Android

### DIFF
--- a/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
+++ b/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java
@@ -79,7 +79,7 @@ public class ReactAztecText extends AztecText {
                 ReactAztecText.this.propagateSelectionChanges(selStart, selEnd);
             }
         });
-        this.setInputType(InputType.TYPE_TEXT_FLAG_CAP_SENTENCES);
+        this.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES | InputType.TYPE_TEXT_FLAG_MULTI_LINE);
     }
 
     @Override


### PR DESCRIPTION
AztecWrapper is currently a one-line field on Android. 

The issue was introduced here https://github.com/wordpress-mobile/react-native-aztec/pull/106 since not all flags were set on the input field.

To test:
- Check out this branch and make sure every block starts capitalized by default and after a period.
- Also make sure that the field is a multi line field by writing long text in it.