### PR TITLE
Update AztecEditor-iOS dependency as 1.4.1

### DIFF
--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -1147,6 +1147,7 @@
 					"$(SRCROOT)/example/**",
 				);
 				INFOPLIST_FILE = example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -1172,6 +1173,7 @@
 					"$(SRCROOT)/example/**",
 				);
 				INFOPLIST_FILE = example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/ios/Cartfile
+++ b/ios/Cartfile
@@ -1,2 +1,2 @@
-github "wordpress-mobile/AztecEditor-iOS" "f946678f319302ac6a8eb2e830a285a1ce9602db"
+github "wordpress-mobile/AztecEditor-iOS" ~> 1.4
 

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wordpress-mobile/AztecEditor-iOS" "f946678f319302ac6a8eb2e830a285a1ce9602db"
+github "wordpress-mobile/AztecEditor-iOS" "1.4.1"


### PR DESCRIPTION
This PR updates AztecEditor-iOS dependency to point to the latest tagged version.

I updated the cartfile to use ~> notation so it will be enough to run `carthage update` in our local to update cartfile.resolved with the latest tagged version.

We are using 'carthage bootstrap' command in the package.json and this command always refers to cartfile.resolved, so we are not causing ambiguous dependencies here.

**To Test:**

- Run `yarn install` `yarn start` and `yarn ios` and verify that example app runs successfully.