### PR TITLE
Bump version number to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-aztec",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "GPL-2.0",
   "scripts": {
     "install-aztec-ios": "cd ./ios && carthage bootstrap --platform iOS --cache-builds",


### PR DESCRIPTION
Bumping the version number to v0.1.5, in preparation of tagging a new release.

To test:

Nothing to test. The newer version will be available when the tag gets created, after merging this PR.